### PR TITLE
YT-PYPF-3: Add basic formatting options

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ on:
       - .github/workflows/tests.yaml
       - src/**
       - test/**
-      - tox.ini
+      - pyproject.toml
 
 jobs:
   run_tests:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install pytest
+          python -m pip install pytest icecream
 
       - name: Run tests for ${{ matrix.python-version }}
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install pytest icecream
+          python -m pip install pytest
 
       - name: Run tests for ${{ matrix.python-version }}
         run: |

--- a/README.md
+++ b/README.md
@@ -4,9 +4,3 @@ Python pretty formatting package
 
 [![tests](https://github.com/SpectraL519/pypformat/actions/workflows/tests.yaml/badge.svg)](https://github.com/SpectraL519/pypformat/actions/workflows/tests)
 [![ruff - linter & formatter](https://github.com/SpectraL519/pypformat/actions/workflows/ruff.yaml/badge.svg)](https://github.com/SpectraL519/pypformat/actions/workflows/ruff)
-
-<br />
-
-## TODO
-
-- Remove the `icecream` dependency from the `test.yaml` workflow before release

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # pypformat
+
 Python pretty formatting package
 
 [![tests](https://github.com/SpectraL519/pypformat/actions/workflows/tests.yaml/badge.svg)](https://github.com/SpectraL519/pypformat/actions/workflows/tests)
 [![ruff - linter & formatter](https://github.com/SpectraL519/pypformat/actions/workflows/ruff.yaml/badge.svg)](https://github.com/SpectraL519/pypformat/actions/workflows/ruff)
+
+<br />
+
+## TODO
+
+- Remove the `icecream` dependency from the `test.yaml` workflow before release

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypformat"
-version = "0.2"
+version = "0.3"
 description = "Python pretty formatting package"
 authors = [
   {name = "SpectraL519"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["ruff", "icecream"]
-test = [ "pytest", "tox"]
+dev = ["ruff", "icecream", "pytest", "tox"]
 
 [project.urls]
 Repository = "https://github.com/SpectraL519/pypformat.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,4 @@ include = ["pformat"]
 [tool.pytest.ini_options]
 testpaths = ["test"]
 pythonpath = ["src"]
+addopts = "--ignore=test/test_dummy.py"

--- a/ruff.toml
+++ b/ruff.toml
@@ -24,5 +24,5 @@ extend-safe-fixes = [
 ]
 "test_*.py" = [
     "E731", # https://www.flake8rules.com/rules/E731.html
-
+    "E712", # https://www.flake8rules.com/rules/E712.html
 ]

--- a/src/pformat/__init__.py
+++ b/src/pformat/__init__.py
@@ -1,3 +1,3 @@
-from .pretty_formatter import PrettyFormatter
 from .format_options import FormatOptions
-from .indentation import indent_size, indent_str, add_indent, add_indents
+from .indentation import add_indent, add_indents, indent_size, indent_str
+from .pretty_formatter import PrettyFormatter

--- a/src/pformat/__init__.py
+++ b/src/pformat/__init__.py
@@ -1,1 +1,3 @@
 from .pretty_formatter import PrettyFormatter
+from .format_options import FormatOptions
+from .indentation import indent_size, indent_str, add_indent, add_indents

--- a/src/pformat/format_options.py
+++ b/src/pformat/format_options.py
@@ -1,0 +1,16 @@
+from dataclasses import MISSING, dataclass
+from typing import Any
+
+
+@dataclass
+class FormatOptions:
+    width: int = 80
+    indent_width: int = 4
+    compact: bool = False
+
+    @staticmethod
+    def default(opt_name: str) -> Any:
+        field = FormatOptions.__dataclass_fields__[opt_name]
+        if field.default_factory is not MISSING:
+            return field.default_factory()
+        return field.default

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -4,6 +4,7 @@ from collections import OrderedDict, deque
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+from .format_options import FormatOptions
 from .formatter_types import MultilineFormatter, NormalFormatter, TypeSpecificFormatter
 from .indentation import add_indents
 
@@ -11,9 +12,9 @@ INDENT_WIDTH = 4
 
 
 class PrettyFormatter:
-    def __init__(self):
+    def __init__(self, options: FormatOptions = FormatOptions()):
+        self._options = options
         self._default_formatter = DefaultFormatter()
-
         self._formatters = OrderedDict(
             [
                 (str, self._default_formatter),
@@ -21,6 +22,20 @@ class PrettyFormatter:
                 (Mapping, MappingFormatter(self)),
                 (Iterable, IterableFormatter(self)),
             ]
+        )
+
+    @staticmethod
+    def new(
+        width: int = FormatOptions.default("width"),
+        indent_width: int = FormatOptions.default("indent_width"),
+        compact: int = FormatOptions.default("compact"),
+    ) -> PrettyFormatter:
+        return PrettyFormatter(
+            options=FormatOptions(
+                width=width,
+                indent_width=indent_width,
+                compact=compact,
+            )
         )
 
     def __call__(self, obj: Any) -> str:

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -6,9 +6,7 @@ from typing import Any
 
 from .format_options import FormatOptions
 from .formatter_types import MultilineFormatter, NormalFormatter, TypeSpecificFormatter
-from .indentation import add_indents
-
-INDENT_WIDTH = 4
+from .indentation import add_indents, indent_size
 
 
 class PrettyFormatter:
@@ -38,45 +36,52 @@ class PrettyFormatter:
             )
         )
 
-    def __call__(self, obj: Any) -> str:
-        return "\n".join(self._format_impl(obj))
+    def __call__(self, obj: Any, depth: int = 0) -> str:
+        return "\n".join(self._format_impl(obj, depth))
 
-    def format(self, obj: Any) -> str:
-        return "\n".join(self._format_impl(obj))
+    def format(self, obj: Any, depth: int = 0) -> str:
+        return "\n".join(self._format_impl(obj, depth))
 
-    def _format_impl(self, obj: Any) -> list[str]:
+    def _format_impl(self, obj: Any, depth: int = 0) -> list[str]:
         for t, formatter in self._formatters.items():
             if isinstance(obj, t):
-                return self._format_with(obj, formatter)
+                return self._format_with(obj, formatter, depth)
 
-        return self._format_with(obj, self._default_formatter)
+        return self._format_with(obj, self._default_formatter, depth)
 
-    def _format_with(self, obj: Any, formatter: TypeSpecificFormatter) -> list[str]:
+    def _format_with(self, obj: Any, formatter: TypeSpecificFormatter, depth: int = 0) -> list[str]:
         if isinstance(formatter, MultilineFormatter):
-            return formatter(obj)
+            return formatter(obj, depth)
 
-        return formatter(obj).split("\n")
+        return formatter(obj, depth).split("\n")
 
 
 class DefaultFormatter(NormalFormatter):
-    def __call__(self, obj: Any) -> str:
+    def __call__(self, obj: Any, depth: int = 0) -> str:
         return repr(obj)
 
 
 class IterableFormatter(MultilineFormatter):
     def __init__(self, base_formatter: PrettyFormatter):
         self._base_formatter = base_formatter
+        self._options = self._base_formatter._options
 
-    def __call__(self, collection: Iterable) -> list[str]:
+    def __call__(self, collection: Iterable, depth: int = 0) -> list[str]:
         opening, closing = IterableFormatter.get_parens(collection)
+
+        if self._options.compact:
+            collecion_str = opening + ", ".join(repr(value) for value in collection) + closing
+            collecion_str_len = len(collecion_str) + indent_size(self._options.indent_width, depth)
+            if self._options.width is None or collecion_str_len <= self._options.width:
+                return [collecion_str]
 
         values = list()
         for value in collection:
-            v_fmt = self._base_formatter._format_impl(value)
+            v_fmt = self._base_formatter._format_impl(value, depth)
             v_fmt[-1] = f"{v_fmt[-1]},"
             values.extend(v_fmt)
 
-        values_fmt = add_indents(values, INDENT_WIDTH, 1)
+        values_fmt = add_indents(values, self._options.indent_width)
         return [opening, *values_fmt, closing]
 
     @staticmethod
@@ -97,15 +102,26 @@ class IterableFormatter(MultilineFormatter):
 class MappingFormatter(MultilineFormatter):
     def __init__(self, base_formatter: PrettyFormatter):
         self._base_formatter = base_formatter
+        self._options = self._base_formatter._options
 
-    def __call__(self, mapping: Mapping) -> list[str]:
+    def __call__(self, mapping: Mapping, depth: int = 0) -> list[str]:
+        if self._options.compact:
+            mapping_str = (
+                "{"
+                + ", ".join(f"{repr(key)}: {repr(value)}" for key, value in mapping.items())
+                + "}"
+            )
+            collecion_str_len = len(mapping_str) + indent_size(self._options.indent_width, depth)
+            if self._options.width is None or collecion_str_len <= self._options.width:
+                return [mapping_str]
+
         values = list()
         for key, value in mapping.items():
             key_fmt = self._base_formatter(key)
-            item_values_fmt = self._base_formatter._format_impl(value)
+            item_values_fmt = self._base_formatter._format_impl(value, depth)
             item_values_fmt[0] = f"{key_fmt}: {item_values_fmt[0]}"
             item_values_fmt[-1] = f"{item_values_fmt[-1]},"
             values.extend(item_values_fmt)
 
-        values_fmt = add_indents(values, INDENT_WIDTH, 1)
+        values_fmt = add_indents(values, self._options.indent_width)
         return ["{", *values_fmt, "}"]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+def pytest_itemcollected(item: pytest.Item):
+    if isinstance(item, pytest.Function):
+        # Replace the `-` separator in parametric test names with `,`
+        item._nodeid = item.nodeid.replace("-", ",")

--- a/test/test_dummy.py
+++ b/test/test_dummy.py
@@ -1,0 +1,62 @@
+from icecream import ic
+
+from pformat import FormatOptions, PrettyFormatter
+
+"""
+This is a dummy test file to empirically test and visualize
+the behaviour of PrettyFormatter
+"""
+
+
+FMT_OPTIONS = {
+    "default": FormatOptions(),
+    "custom": FormatOptions(
+        width=40,
+        indent_width=3,
+        compact=True,
+    ),
+}
+
+
+def test_dummy_collection():
+    print()
+
+    collection = [
+        1,
+        2,
+        {"key3": 3, "key4": {"key5": 5, "key6": 6}},
+        {8, 7},
+        frozenset({9, 10}),
+        (11, 12),
+        "string",
+        b"f\xcd\x11",
+    ]
+
+    ic(collection)
+    print("\n" + ("-" * 50) + "\n")
+
+    for config_name, fmt_opt in FMT_OPTIONS.items():
+        ic(config_name)
+        fmt = PrettyFormatter(fmt_opt)
+        print(fmt(collection), end="\n" * 3)
+
+
+def test_dummy_mapping():
+    print()
+
+    mapping = {
+        "key1": 1,
+        "key2": {"key3": 3, "key4": 4},
+        "key5": {
+            "key6": 6,
+            "super_turbo_long_mega_key7": {"key10": [10, 11, 12, 13], "key8": 8, "key9": 9},
+        },
+    }
+
+    ic(mapping)
+    print("\n" + ("-" * 50) + "\n")
+
+    for config_name, fmt_opt in FMT_OPTIONS.items():
+        ic(config_name, fmt_opt)
+        fmt = PrettyFormatter(fmt_opt)
+        print(fmt(mapping), end="\n" * 3)

--- a/test/test_format_options.py
+++ b/test/test_format_options.py
@@ -1,0 +1,7 @@
+from pformat.format_options import FormatOptions
+
+
+def test_default():
+    assert FormatOptions.default("width") == 80
+    assert FormatOptions.default("indent_width") == 4
+    assert FormatOptions.default("compact") == False

--- a/test/test_format_options.py
+++ b/test/test_format_options.py
@@ -1,3 +1,5 @@
+from dataclasses import field
+
 from pformat.format_options import FormatOptions
 
 
@@ -5,3 +7,8 @@ def test_default():
     assert FormatOptions.default("width") == 80
     assert FormatOptions.default("indent_width") == 4
     assert FormatOptions.default("compact") == False
+
+    # Dummy field with a default factory
+    list_field = "list"
+    FormatOptions.__dataclass_fields__[list_field] = field(default_factory=list)
+    assert FormatOptions.default(list_field) == list()

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -6,7 +6,10 @@ import pytest
 
 from pformat.format_options import FormatOptions
 from pformat.indentation import add_indent, add_indents
-from pformat.pretty_formatter import INDENT_WIDTH, IterableFormatter, PrettyFormatter
+from pformat.pretty_formatter import IterableFormatter, PrettyFormatter
+
+SIMPLE_DATA = [123, 3.14, "string", b"bytes"]
+INDENT_WIDTH = FormatOptions.default("indent_width")
 
 
 class TestPrettyFormatterInitialization:
@@ -31,9 +34,6 @@ class TestPrettyFormatterInitialization:
 
         sut_new = PrettyFormatter.new(**asdict(custom_options))
         assert sut_new._options == custom_options
-
-
-SIMPLE_DATA = [123, 3.14, "string", b"bytes"]
 
 
 def gen_mapping(data: Iterable) -> dict:

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -1,10 +1,37 @@
 from collections import deque
 from collections.abc import Iterable
+from dataclasses import asdict
 
 import pytest
 
+from pformat.format_options import FormatOptions
 from pformat.indentation import add_indent, add_indents
 from pformat.pretty_formatter import INDENT_WIDTH, IterableFormatter, PrettyFormatter
+
+
+class TestPrettyFormatterInitialization:
+    def test_default_init(self):
+        "Should be initialized with the default format options"
+
+        sut = PrettyFormatter()
+        assert sut._options == FormatOptions()
+
+        sut_new = PrettyFormatter.new()
+        assert sut_new._options == FormatOptions()
+
+    def test_custom_init(self):
+        custom_options = FormatOptions(
+            width=100,
+            indent_width=3,
+            compact=True,
+        )
+
+        sut = PrettyFormatter(custom_options)
+        assert sut._options == custom_options
+
+        sut_new = PrettyFormatter.new(**asdict(custom_options))
+        assert sut_new._options == custom_options
+
 
 SIMPLE_DATA = [123, 3.14, "string", b"bytes"]
 

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -8,8 +8,15 @@ from pformat.format_options import FormatOptions
 from pformat.indentation import add_indent, add_indents
 from pformat.pretty_formatter import IterableFormatter, PrettyFormatter
 
-SIMPLE_DATA = [123, 3.14, "string", b"bytes"]
-INDENT_WIDTH = FormatOptions.default("indent_width")
+
+def test_iterable_formatter_get_parnens():
+    assert IterableFormatter.get_parens(list()) == ("[", "]")
+    assert IterableFormatter.get_parens(set()) == ("{", "}")
+    assert IterableFormatter.get_parens(frozenset()) == ("frozen{", "}")
+    assert IterableFormatter.get_parens(tuple()) == ("(", ")")
+    assert IterableFormatter.get_parens(range(3)) == ("(", ")")
+    assert IterableFormatter.get_parens(deque()) == ("deque([", "])")
+    assert IterableFormatter.get_parens(DummyIterable()) == ("![", "]!")
 
 
 class TestPrettyFormatterInitialization:
@@ -38,6 +45,10 @@ class TestPrettyFormatterInitialization:
 
 def gen_mapping(data: Iterable) -> dict:
     return {f"key{i}": value for i, value in enumerate(data)}
+
+
+SIMPLE_DATA = [123, 3.14, "string", b"bytes"]
+INDENT_WIDTH = FormatOptions.default("indent_width")
 
 
 class DummyIterable:
@@ -171,13 +182,3 @@ class TestPrettyFormatterNestedStructures:
 
         assert sut(mapping) == expected_output
         assert sut.format(mapping) == expected_output
-
-
-def test_iterable_formatter_get_parnens():
-    assert IterableFormatter.get_parens(list()) == ("[", "]")
-    assert IterableFormatter.get_parens(set()) == ("{", "}")
-    assert IterableFormatter.get_parens(frozenset()) == ("frozen{", "}")
-    assert IterableFormatter.get_parens(tuple()) == ("(", ")")
-    assert IterableFormatter.get_parens(range(3)) == ("(", ")")
-    assert IterableFormatter.get_parens(deque()) == ("deque([", "])")
-    assert IterableFormatter.get_parens(DummyIterable()) == ("![", "]!")

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, py312, coverage
+envlist = py39, py310, py311, py312, py313, coverage
 skip_missing_interpreters = True
 
 
@@ -48,3 +48,4 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313


### PR DESCRIPTION
Added:
- the `FormatOptions` class with the `width`, `indent_width` and `compact` fields
- the `options` parameter to the constructor of `PrettyFormatter`
- the `new` static method to the `PrettyFormatter` class