### PR TITLE
YT-PYPF-5: Add the advanced formatting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,10 @@ Python pretty formatting package
 
 [![tests](https://github.com/SpectraL519/pypformat/actions/workflows/tests.yaml/badge.svg)](https://github.com/SpectraL519/pypformat/actions/workflows/tests)
 [![ruff - linter & formatter](https://github.com/SpectraL519/pypformat/actions/workflows/ruff.yaml/badge.svg)](https://github.com/SpectraL519/pypformat/actions/workflows/ruff)
+
+<br />
+
+## TODO
+
+- Remove `test_dummy.py` before release
+- Add the important/caution note about using projections - don't project a type onto a list of the same type - infinite recursion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypformat"
-version = "0.3"
+version = "0.4"
 description = "Python pretty formatting package"
 authors = [
   {name = "SpectraL519"}

--- a/src/pformat/__init__.py
+++ b/src/pformat/__init__.py
@@ -1,3 +1,19 @@
+from .common_types import (
+    MultilineTypeFormatterFunc,
+    NormalTypeFormatterFunc,
+    TypeFormatterFuncSequence,
+    TypeProjectionFunc,
+    TypeProjectionFuncMapping,
+)
 from .format_options import FormatOptions
+from .formatter_types import (
+    CustomMultilineFormatter,
+    CustomNormalFormatter,
+    MultilineFormatter,
+    NormalFormatter,
+    TypeFormatter,
+    multiline_formatter,
+    normal_formatter,
+)
 from .indentation import add_indent, add_indents, indent_size, indent_str
-from .pretty_formatter import PrettyFormatter
+from .pretty_formatter import DefaultFormatter, IterableFormatter, MappingFormatter, PrettyFormatter

--- a/src/pformat/common_types.py
+++ b/src/pformat/common_types.py
@@ -1,9 +1,9 @@
 from collections.abc import Mapping
-from typing import Any, Callable
+from typing import Any, Callable, Union
 
 TypeProjectionFunc = Callable[[object], Any]
 TypeProjectionFuncMapping = Mapping[type, TypeProjectionFunc]
 
 NormalTypeFormatterFunc = Callable[[object, int], str]
 MultilineTypeFormatterFunc = Callable[[object, int], str]
-TypeFormatterFuncMapping = Mapping[type, NormalTypeFormatterFunc | MultilineTypeFormatterFunc]
+TypeFormatterFuncMapping = Mapping[type, Union[NormalTypeFormatterFunc, MultilineTypeFormatterFunc]]

--- a/src/pformat/common_types.py
+++ b/src/pformat/common_types.py
@@ -1,0 +1,9 @@
+from collections.abc import Mapping
+from typing import Any, Callable
+
+TypeProjectionFunc = Callable[[object], Any]
+TypeProjectionFuncMapping = Mapping[type, TypeProjectionFunc]
+
+NormalTypeFormatterFunc = Callable[[object, int], str]
+MultilineTypeFormatterFunc = Callable[[object, int], str]
+TypeFormatterFuncMapping = Mapping[type, NormalTypeFormatterFunc | MultilineTypeFormatterFunc]

--- a/src/pformat/common_types.py
+++ b/src/pformat/common_types.py
@@ -1,4 +1,4 @@
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableSequence
 from typing import Any, Callable, Union
 
 TypeProjectionFunc = Callable[[object], Any]
@@ -6,4 +6,6 @@ TypeProjectionFuncMapping = Mapping[type, TypeProjectionFunc]
 
 NormalTypeFormatterFunc = Callable[[object, int], str]
 MultilineTypeFormatterFunc = Callable[[object, int], str]
-TypeFormatterFuncMapping = Mapping[type, Union[NormalTypeFormatterFunc, MultilineTypeFormatterFunc]]
+TypeFormatterFuncSequence = MutableSequence[
+    type, Union[NormalTypeFormatterFunc, MultilineTypeFormatterFunc]
+]

--- a/src/pformat/format_options.py
+++ b/src/pformat/format_options.py
@@ -1,9 +1,7 @@
-from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
-TypeProjection = Callable[[object], Any]
-TypeProjectionMapping = Mapping[type, TypeProjection]
+from .common_types import TypeFormatterFuncMapping, TypeProjectionFuncMapping
 
 
 @dataclass
@@ -11,7 +9,8 @@ class FormatOptions:
     width: Optional[int] = 80
     indent_width: int = 4
     compact: bool = False
-    projections: Optional[TypeProjectionMapping] = None
+    projections: Optional[TypeProjectionFuncMapping] = None
+    formatters: Optional[TypeFormatterFuncMapping] = None
 
     @staticmethod
     def default(opt_name: str) -> Any:

--- a/src/pformat/format_options.py
+++ b/src/pformat/format_options.py
@@ -1,16 +1,18 @@
-from dataclasses import MISSING, dataclass
-from typing import Any
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+TypeProjection = Callable[[object], Any]
+TypeProjectionMapping = Mapping[type, TypeProjection]
 
 
 @dataclass
 class FormatOptions:
-    width: int = 80
+    width: Optional[int] = 80
     indent_width: int = 4
     compact: bool = False
+    projections: Optional[TypeProjectionMapping] = None
 
     @staticmethod
     def default(opt_name: str) -> Any:
-        field = FormatOptions.__dataclass_fields__[opt_name]
-        if field.default_factory is not MISSING:
-            return field.default_factory()
-        return field.default
+        return FormatOptions.__dataclass_fields__[opt_name].default

--- a/src/pformat/format_options.py
+++ b/src/pformat/format_options.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Optional
 
-from .common_types import TypeFormatterFuncMapping, TypeProjectionFuncMapping
+from .common_types import TypeFormatterFuncSequence, TypeProjectionFuncMapping
 
 
 @dataclass
@@ -10,7 +10,7 @@ class FormatOptions:
     indent_width: int = 4
     compact: bool = False
     projections: Optional[TypeProjectionFuncMapping] = None
-    formatters: Optional[TypeFormatterFuncMapping] = None
+    formatters: Optional[TypeFormatterFuncSequence] = None
 
     @staticmethod
     def default(opt_name: str) -> Any:

--- a/src/pformat/formatter_types.py
+++ b/src/pformat/formatter_types.py
@@ -9,15 +9,17 @@ class TypeFormatter:
     def __init__(self, t: type):
         self._type = t
 
-    def __call__(self, obj: Any, depth: int) -> str:
-        raise NotImplementedError
+    def __call__(self, obj: Any, depth: int = 0) -> str:
+        raise NotImplementedError(f"{repr(self)}.__call__ is not implemented")
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._type.__name__})"
 
     def _check_type(self, obj: Any) -> None:
         if not isinstance(obj, self._type):
-            raise TypeError(f"[{repr(self)}] Cannot format an object of type `{type(obj).__name__}`")
+            raise TypeError(
+                f"[{repr(self)}] Cannot format an object of type `{type(obj).__name__}`"
+            )
 
 
 class NormalFormatter(TypeFormatter):
@@ -28,7 +30,11 @@ class NormalFormatter(TypeFormatter):
 class CustomNormalFormatter(NormalFormatter):
     def __init__(self, t: type, fmt_func: NormalTypeFormatterFunc):
         super().__init__(t)
-        self.__call__ = fmt_func
+        self.__fmt_func = fmt_func
+
+    def __call__(self, obj: Any, depth: int = 0) -> str:
+        self._check_type(obj)
+        return self.__fmt_func(obj, depth)
 
 
 class MultilineFormatter(TypeFormatter):
@@ -39,4 +45,8 @@ class MultilineFormatter(TypeFormatter):
 class CustomMultilineFormatter(MultilineFormatter):
     def __init__(self, t: type, fmt_func: MultilineTypeFormatterFunc):
         super().__init__(t)
-        self.__call__ = fmt_func
+        self.__fmt_func = fmt_func
+
+    def __call__(self, obj: Any, depth: int = 0) -> str:
+        self._check_type(obj)
+        return self.__fmt_func(obj, depth)

--- a/src/pformat/formatter_types.py
+++ b/src/pformat/formatter_types.py
@@ -7,18 +7,31 @@ from .common_types import MultilineTypeFormatterFunc, NormalTypeFormatterFunc
 
 class TypeFormatter:
     def __init__(self, t: type):
-        self._type = t
+        self.type = t
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, TypeFormatter):
+            raise TypeError(
+                f"Cannot compare a `{self.__class__.__name__}` instance to an instance of `{type(other).__name__}`"
+            )
+
+        return self.type == other.type
 
     def __call__(self, obj: Any, depth: int = 0) -> str:
         raise NotImplementedError(f"{repr(self)}.__call__ is not implemented")
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({self._type.__name__})"
+        return f"{self.__class__.__name__}({self.type.__name__})"
+
+    def is_valid(self, obj: Any) -> None:
+        if self.type is Any:
+            return True
+        return isinstance(obj, self.type)
 
     def _check_type(self, obj: Any) -> None:
-        if not isinstance(obj, self._type):
+        if not isinstance(obj, self.type):
             raise TypeError(
-                f"[{repr(self)}] Cannot format an object of type `{type(obj).__name__}`"
+                f"[{repr(self)}] Cannot format an object of type `{type(obj).__name__}` - `{str(obj)}`"
             )
 
 
@@ -37,6 +50,10 @@ class CustomNormalFormatter(NormalFormatter):
         return self.__fmt_func(obj, depth)
 
 
+def normal_formatter(t: type, fmt_func: NormalTypeFormatterFunc) -> CustomNormalFormatter:
+    return CustomNormalFormatter(t, fmt_func)
+
+
 class MultilineFormatter(TypeFormatter):
     def __init__(self, t: type):
         super().__init__(t)
@@ -50,3 +67,7 @@ class CustomMultilineFormatter(MultilineFormatter):
     def __call__(self, obj: Any, depth: int = 0) -> str:
         self._check_type(obj)
         return self.__fmt_func(obj, depth)
+
+
+def multiline_formatter(t: type, fmt_func: MultilineTypeFormatterFunc) -> CustomMultilineFormatter:
+    return CustomMultilineFormatter(t, fmt_func)

--- a/src/pformat/formatter_types.py
+++ b/src/pformat/formatter_types.py
@@ -1,10 +1,42 @@
-class TypeSpecificFormatter:
-    pass
+from __future__ import annotations
+
+from typing import Any
+
+from .common_types import MultilineTypeFormatterFunc, NormalTypeFormatterFunc
 
 
-class NormalFormatter(TypeSpecificFormatter):
-    pass
+class TypeFormatter:
+    def __init__(self, t: type):
+        self._type = t
+
+    def __call__(self, obj: Any, depth: int) -> str:
+        raise NotImplementedError
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}({self._type.__name__})"
+
+    def _check_type(self, obj: Any) -> None:
+        if not isinstance(obj, self._type):
+            raise TypeError(f"[{repr(self)}] Cannot format an object of type `{type(obj).__name__}`")
 
 
-class MultilineFormatter(TypeSpecificFormatter):
-    pass
+class NormalFormatter(TypeFormatter):
+    def __init__(self, t: type):
+        super().__init__(t)
+
+
+class CustomNormalFormatter(NormalFormatter):
+    def __init__(self, t: type, fmt_func: NormalTypeFormatterFunc):
+        super().__init__(t)
+        self.__call__ = fmt_func
+
+
+class MultilineFormatter(TypeFormatter):
+    def __init__(self, t: type):
+        super().__init__(t)
+
+
+class CustomMultilineFormatter(MultilineFormatter):
+    def __init__(self, t: type, fmt_func: MultilineTypeFormatterFunc):
+        super().__init__(t)
+        self.__call__ = fmt_func

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -92,6 +92,8 @@ class IterableFormatter(MultilineFormatter):
         self._options = self._base_formatter._options
 
     def __call__(self, collection: Iterable, depth: int = 0) -> list[str]:
+        self._check_type(collection)  # TODO: add tests
+
         opening, closing = IterableFormatter.get_parens(collection)
 
         if self._options.compact:
@@ -131,6 +133,8 @@ class MappingFormatter(MultilineFormatter):
         self._options = self._base_formatter._options
 
     def __call__(self, mapping: Mapping, depth: int = 0) -> list[str]:
+        self._check_type(mapping)  # TODO: add tests
+
         if self._options.compact:
             mapping_str = (
                 "{"

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -128,6 +128,8 @@ class IterableFormatter(MultilineFormatter):
             return "frozen{", "}"
         if isinstance(collection, tuple) or isinstance(collection, range):
             return "(", ")"
+        if isinstance(collection, bytearray):
+            return "bytearray(", ")"
         if isinstance(collection, deque):
             return "deque([", "])"
         return "![", "]!"

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -104,7 +104,9 @@ class IterableFormatter(MultilineFormatter):
         opening, closing = IterableFormatter.get_parens(collection)
 
         if self._options.compact:
-            collecion_str = opening + ", ".join(repr(value) for value in collection) + closing
+            collecion_str = (
+                opening + ", ".join(self._base_formatter(value) for value in collection) + closing
+            )
             collecion_str_len = len(collecion_str) + indent_size(self._options.indent_width, depth)
             if self._options.width is None or collecion_str_len <= self._options.width:
                 return [collecion_str]
@@ -147,7 +149,10 @@ class MappingFormatter(MultilineFormatter):
         if self._options.compact:
             mapping_str = (
                 "{"
-                + ", ".join(f"{repr(key)}: {repr(value)}" for key, value in mapping.items())
+                + ", ".join(
+                    f"{self._base_formatter(key)}: {self._base_formatter(value)}"
+                    for key, value in mapping.items()
+                )
                 + "}"
             )
             collecion_str_len = len(mapping_str) + indent_size(self._options.indent_width, depth)

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -99,7 +99,7 @@ class IterableFormatter(MultilineFormatter):
         self._options = self._base_formatter._options
 
     def __call__(self, collection: Iterable, depth: int = 0) -> list[str]:
-        self._check_type(collection)  # TODO: add tests
+        self._check_type(collection)
 
         opening, closing = IterableFormatter.get_parens(collection)
 
@@ -140,7 +140,7 @@ class MappingFormatter(MultilineFormatter):
         self._options = self._base_formatter._options
 
     def __call__(self, mapping: Mapping, depth: int = 0) -> list[str]:
-        self._check_type(mapping)  # TODO: add tests
+        self._check_type(mapping)
 
         if self._options.compact:
             mapping_str = (

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,5 @@
+from typing import Callable
+
 import pytest
 
 
@@ -5,3 +7,10 @@ def pytest_itemcollected(item: pytest.Item):
     if isinstance(item, pytest.Function):
         # Replace the `-` separator in parametric test names with `,`
         item._nodeid = item.nodeid.replace("-", ",")
+
+
+def assert_does_not_throw(func: Callable, *args, **kwargs):
+    try:
+        func(*args, **kwargs)
+    except Exception as e:
+        pytest.fail(f"Function `{func.__name__}` raised an exception: {e}")

--- a/test/test_dummy.py
+++ b/test/test_dummy.py
@@ -10,10 +10,18 @@ the behaviour of PrettyFormatter
 
 FMT_OPTIONS = {
     "default": FormatOptions(),
-    "custom": FormatOptions(
+    "compact": FormatOptions(
         width=40,
         indent_width=3,
         compact=True,
+    ),
+    "custom - projections": FormatOptions(
+        width=40,
+        compact=True,
+        projections={
+            float: lambda f: int(f),
+            bytes: lambda b: bytearray(b),
+        },
     ),
 }
 

--- a/test/test_dummy.py
+++ b/test/test_dummy.py
@@ -1,6 +1,6 @@
 from icecream import ic
 
-from pformat import FormatOptions, PrettyFormatter
+from pformat import FormatOptions, PrettyFormatter, normal_formatter
 
 """
 This is a dummy test file to empirically test and visualize
@@ -23,6 +23,15 @@ FMT_OPTIONS = {
             bytes: lambda b: bytearray(b),
         },
     ),
+    "custom - formatters": FormatOptions(
+        width=40,
+        compact=True,
+        formatters=[
+            normal_formatter(int, lambda i, _: f"{i:.1f}"),
+            normal_formatter(float, lambda f, _: f"{f:.2f}"),
+            normal_formatter(str, lambda s, _: f'str"{s}"'),
+        ],
+    ),
 }
 
 
@@ -31,7 +40,7 @@ def test_dummy_collection():
 
     collection = [
         1,
-        2,
+        2.123,
         {"key3": 3, "key4": {"key5": 5, "key6": 6}},
         {8, 7},
         frozenset({9, 10}),

--- a/test/test_format_options.py
+++ b/test/test_format_options.py
@@ -6,3 +6,4 @@ def test_default():
     assert FormatOptions.default("indent_width") == 4
     assert FormatOptions.default("compact") == False
     assert FormatOptions.default("projections") is None
+    assert FormatOptions.default("formatters") is None

--- a/test/test_format_options.py
+++ b/test/test_format_options.py
@@ -1,5 +1,3 @@
-from dataclasses import field
-
 from pformat.format_options import FormatOptions
 
 
@@ -7,8 +5,4 @@ def test_default():
     assert FormatOptions.default("width") == 80
     assert FormatOptions.default("indent_width") == 4
     assert FormatOptions.default("compact") == False
-
-    # Dummy field with a default factory
-    list_field = "list"
-    FormatOptions.__dataclass_fields__[list_field] = field(default_factory=list)
-    assert FormatOptions.default(list_field) == list()
+    assert FormatOptions.default("projections") is None

--- a/test/test_formatter_types.py
+++ b/test/test_formatter_types.py
@@ -1,0 +1,100 @@
+import pytest
+
+from pformat.formatter_types import (
+    CustomMultilineFormatter,
+    CustomNormalFormatter,
+    MultilineFormatter,
+    NormalFormatter,
+    TypeFormatter,
+)
+
+from .conftest import assert_does_not_throw
+
+TYPES_DICT = {
+    int: 123,
+    float: 3.14,
+    str: "string",
+    bytes: b"bytes",
+    list: [1, 2, 3],
+    dict: {"k1": 1, "k2": 2},
+}
+TYPES_KEYS = list(TYPES_DICT.keys())
+
+
+class InvalidType:
+    pass
+
+
+class TestTypeFormatterRepr:
+    FORMATTER_TYPES = (TypeFormatter, NormalFormatter, MultilineFormatter)
+
+    @pytest.fixture(autouse=True, params=TYPES_KEYS, ids=[f"t={t.__name__}" for t in TYPES_KEYS])
+    def set_type_param(self, request: pytest.FixtureRequest) -> TypeFormatter:
+        self.type = request.param
+
+    @pytest.mark.parametrize(
+        "fmt_type",
+        FORMATTER_TYPES,
+        ids=[f"fmt_type={fmt_type.__name__}" for fmt_type in FORMATTER_TYPES],
+    )
+    def test_repr(self, fmt_type: type):
+        sut = fmt_type(self.type)
+        assert repr(sut) == f"{fmt_type.__name__}({self.type.__name__})"
+
+
+class TestTypeFormatter:
+    @pytest.fixture(params=TYPES_KEYS, ids=[f"t={t.__name__}" for t in TYPES_KEYS])
+    def sut(self, request: pytest.FixtureRequest) -> TypeFormatter:
+        self.type = request.param
+        return TypeFormatter(self.type)
+
+    def test_call(self, sut: TypeFormatter):
+        with pytest.raises(NotImplementedError) as err:
+            sut(self.type())
+
+        assert str(err.value) == f"{repr(sut)}.__call__ is not implemented"
+
+    def test_check_type_invalid(self, sut: TypeFormatter):
+        with pytest.raises(TypeError) as err:
+            sut._check_type(InvalidType())
+
+        assert str(err.value) == f"[{repr(sut)}] Cannot format an object of type `InvalidType`"
+
+    def test_check_type_valid(self, sut: TypeFormatter):
+        assert_does_not_throw(sut._check_type, self.type())
+
+
+class TestCustomNormalFormatter:
+    @pytest.fixture(params=TYPES_KEYS, ids=[f"t={t.__name__}" for t in TYPES_KEYS])
+    def sut(self, request: pytest.FixtureRequest) -> CustomNormalFormatter:
+        self.type = request.param
+        self.fmt_func = lambda obj, depth: str(obj)
+        return CustomNormalFormatter(self.type, self.fmt_func)
+
+    def test_call_with_invalid_type(self, sut: CustomNormalFormatter):
+        with pytest.raises(TypeError) as err:
+            sut(InvalidType())
+
+        assert str(err.value) == f"[{repr(sut)}] Cannot format an object of type `InvalidType`"
+
+    def test_call_with_correct_type(self, sut: CustomNormalFormatter):
+        value = TYPES_DICT[self.type]
+        assert sut(value) == self.fmt_func(value, depth=0)
+
+
+class TestCustomMultilineFormatter:
+    @pytest.fixture(params=TYPES_KEYS, ids=[f"t={t.__name__}" for t in TYPES_KEYS])
+    def sut(self, request: pytest.FixtureRequest) -> CustomMultilineFormatter:
+        self.type = request.param
+        self.fmt_func = lambda obj, depth: [str(obj)]
+        return CustomMultilineFormatter(self.type, self.fmt_func)
+
+    def test_call_with_invalid_type(self, sut: CustomMultilineFormatter):
+        with pytest.raises(TypeError) as err:
+            sut(InvalidType())
+
+        assert str(err.value) == f"[{repr(sut)}] Cannot format an object of type `InvalidType`"
+
+    def test_call_with_correct_type(self, sut: CustomMultilineFormatter):
+        value = TYPES_DICT[self.type]
+        assert sut(value) == self.fmt_func(value, depth=0)

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -334,6 +334,6 @@ class TestPrettyFormatterProjections:
         assert sut.format(f) == repr(f)
 
 
-class TestPrettyFormatterCustomFormatters():
-    def test_format_elements_with_overriden_formatters(self):
-        sut = PrettyFormatter
+# class TestPrettyFormatterCustomFormatters():
+#     def test_format_elements_with_overriden_formatters(self):
+#         sut = PrettyFormatter

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -292,25 +292,17 @@ class TestPrettyFormatterCompactForNestedMappingTypes:
 
 class TestPrettyFormatterProjections:
     def test_format_projected_elements(self):
-        int_proj = lambda i: i**2
         float_proj = lambda f: int(f) + 1
-        str_proj = lambda s: [c for c in s]
+        str_proj = lambda s: [ord(c) for c in s]
 
         sut = PrettyFormatter.new(
             compact=True,
             width=None,
             projections={
-                int: int_proj,
                 float: float_proj,
                 str: str_proj,
             },
         )
-
-        i = 123
-        assert int_proj(i) != i
-        assert sut(i) != repr(i)
-        assert sut(i) == repr(int_proj(i))
-        assert sut.format(i) == repr(int_proj(i))
 
         f = 3.14
         assert float_proj(f) != f

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -16,6 +16,7 @@ def test_iterable_formatter_get_parnens():
     assert IterableFormatter.get_parens(frozenset()) == ("frozen{", "}")
     assert IterableFormatter.get_parens(tuple()) == ("(", ")")
     assert IterableFormatter.get_parens(range(3)) == ("(", ")")
+    assert IterableFormatter.get_parens(bytearray()) == ("bytearray(", ")")
     assert IterableFormatter.get_parens(deque()) == ("deque([", "])")
     assert IterableFormatter.get_parens(DummyIterable()) == ("![", "]!")
 

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -332,3 +332,8 @@ class TestPrettyFormatterProjections:
         f = 3.14
         assert sut(f) == repr(f)
         assert sut.format(f) == repr(f)
+
+
+class TestPrettyFormatterCustomFormatters():
+    def test_format_elements_with_overriden_formatters(self):
+        sut = PrettyFormatter

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -286,3 +286,49 @@ class TestPrettyFormatterCompactForNestedMappingTypes:
 
         assert sut(mapping) == expected_output
         assert sut.format(mapping) == expected_output
+
+
+class TestPrettyFormatterProjections:
+    def test_format_projected_elements(self):
+        int_proj = lambda i: i**2
+        float_proj = lambda f: int(f) + 1
+        str_proj = lambda s: [c for c in s]
+
+        sut = PrettyFormatter.new(
+            compact=True,
+            width=None,
+            projections={
+                int: int_proj,
+                float: float_proj,
+                str: str_proj,
+            },
+        )
+
+        i = 123
+        assert int_proj(i) != i
+        assert sut(i) != repr(i)
+        assert sut(i) == repr(int_proj(i))
+        assert sut.format(i) == repr(int_proj(i))
+
+        f = 3.14
+        assert float_proj(f) != f
+        assert sut(f) != repr(f)
+        assert sut(f) == repr(float_proj(f))
+        assert sut.format(f) == repr(float_proj(f))
+
+        s = "string"
+        assert str_proj(s) != s
+        assert sut(s) != repr(s)
+        assert sut(s) == repr(str_proj(s))
+        assert sut.format(s) == repr(str_proj(s))
+
+    def test_format_projected_elements_with_no_matchin_projection(self):
+        sut = PrettyFormatter.new(
+            compact=True,
+            width=None,
+            projections=dict(),
+        )
+
+        f = 3.14
+        assert sut(f) == repr(f)
+        assert sut.format(f) == repr(f)


### PR DESCRIPTION
- Extended the functionality of the `TypeFormatter`, `NormalForamtter` and `MultilineFormatter` classes
- Added the `CustomNormalFormatter` and `CustomMultilineFormatter` classes with dedicated builder functions
- Added the `projections` and `formatters` parameters to the `FormatOptions` and `PrettyFormatter` classes