### PR TITLE
YT-PYPF-6: Add the text coloring options

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install pytest
+          python -m pip install -r requirements-ci-tests.txt
 
       - name: Run tests for ${{ matrix.python-version }}
         run: |

--- a/README.md
+++ b/README.md
@@ -10,4 +10,7 @@ Python pretty formatting package
 ## TODO
 
 - Remove `test_dummy.py` before release
-- Add the important/caution note about using projections - don't project a type onto a list of the same type - infinite recursion
+- Add notes:
+  - (important/caution) using projections:
+    - don't project a type onto a list of the same type - infinite recursion
+    - `text_style` may/will not be applied for custom-formatted types with `style_entire_text=False`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypformat"
-version = "0.6"
+version = "0.7"
 description = "Python pretty formatting package"
 authors = [
   {name = "SpectraL519"}
@@ -13,6 +13,7 @@ authors = [
 readme = {file = "README.md", content-type = "text/markdown; charset=UTF-8; variant=GFM"}
 license = {file = "LICENSE"}
 requires-python = ">= 3.9"
+dependencies = ["colored==2.2.4"]
 keywords = ["pretty", "formatting", "format", "print"]
 classifiers = [
   "Development Status :: 2 - Pre-Alpha",
@@ -31,7 +32,7 @@ classifiers = [
 ]
 
 [project.optional-dependencies]
-dev = ["ruff", "icecream", "pytest", "tox"]
+dev = ["pytest", "tox", "ruff", "icecream"]
 
 [project.urls]
 Repository = "https://github.com/SpectraL519/pypformat.git"

--- a/requirements-ci-tests.txt
+++ b/requirements-ci-tests.txt
@@ -1,0 +1,2 @@
+pytest
+colored==2.2.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+colored==2.2.4
 pytest
 ruff
 tox

--- a/src/pformat/__init__.py
+++ b/src/pformat/__init__.py
@@ -5,7 +5,7 @@ from .common_types import (
     TypeProjectionFunc,
     TypeProjectionFuncMapping,
 )
-from .format_options import FormatOptions
+from .format_options import ApplyTextStyleTo, FormatOptions
 from .formatter_types import (
     CustomMultilineFormatter,
     CustomNormalFormatter,
@@ -17,3 +17,4 @@ from .formatter_types import (
 )
 from .indentation_utility import IndentMarker, IndentType
 from .pretty_formatter import DefaultFormatter, IterableFormatter, MappingFormatter, PrettyFormatter
+from .text_style import TextStyle, TextStyleParam, TextStyleValue

--- a/src/pformat/__init__.py
+++ b/src/pformat/__init__.py
@@ -5,7 +5,7 @@ from .common_types import (
     TypeProjectionFunc,
     TypeProjectionFuncMapping,
 )
-from .format_options import ApplyTextStyleTo, FormatOptions
+from .format_options import FormatOptions
 from .formatter_types import (
     CustomMultilineFormatter,
     CustomNormalFormatter,

--- a/src/pformat/__init__.py
+++ b/src/pformat/__init__.py
@@ -17,4 +17,10 @@ from .formatter_types import (
 )
 from .indentation_utility import IndentMarker, IndentType
 from .pretty_formatter import DefaultFormatter, IterableFormatter, MappingFormatter, PrettyFormatter
-from .text_style import TextStyle, TextStyleParam, TextStyleValue
+from .text_style import (
+    TextStyle,
+    TextStyleParam,
+    TextStyleValue,
+    rm_style_modifiers,
+    strlen_no_style,
+)

--- a/src/pformat/format_options.py
+++ b/src/pformat/format_options.py
@@ -1,8 +1,15 @@
 from dataclasses import MISSING, asdict, dataclass, field, fields
+from enum import Enum, auto
 from typing import Any, Optional
 
 from .common_types import TypeFormatterFuncSequence, TypeProjectionFuncMapping
 from .indentation_utility import IndentType
+from .text_style import TextStyle
+
+
+class ApplyTextStyleTo(Enum):
+    all = auto()
+    values_only = auto()
 
 
 @dataclass
@@ -10,8 +17,16 @@ class FormatOptions:
     width: Optional[int] = 80
     compact: bool = False
     indent_type: IndentType = field(default_factory=lambda: IndentType.NONE())
+    text_style: TextStyle = field(default_factory=TextStyle)
+    apply_text_style_to: ApplyTextStyleTo = (
+        ApplyTextStyleTo.all,
+    )  # TODO: add proper handling in PrettyFormatter
     projections: Optional[TypeProjectionFuncMapping] = None
     formatters: Optional[TypeFormatterFuncSequence] = None
+
+    def __post_init__(self):
+        if not isinstance(self.text_style, TextStyle):
+            self.text_style = TextStyle.new(self.text_style)
 
     def asdict(self, shallow: bool = True) -> dict:
         if shallow:

--- a/src/pformat/format_options.py
+++ b/src/pformat/format_options.py
@@ -12,7 +12,7 @@ class FormatOptions:
     compact: bool = False
     indent_type: IndentType = field(default_factory=lambda: IndentType.NONE())
     text_style: TextStyle = field(default_factory=TextStyle)
-    text_style_full: bool = False
+    style_entire_text: bool = False
     projections: Optional[TypeProjectionFuncMapping] = None
     formatters: Optional[TypeFormatterFuncSequence] = None
 

--- a/src/pformat/format_options.py
+++ b/src/pformat/format_options.py
@@ -1,15 +1,9 @@
 from dataclasses import MISSING, asdict, dataclass, field, fields
-from enum import Enum, auto
 from typing import Any, Optional
 
 from .common_types import TypeFormatterFuncSequence, TypeProjectionFuncMapping
 from .indentation_utility import IndentType
 from .text_style import TextStyle
-
-
-class ApplyTextStyleTo(Enum):
-    all = auto()
-    values_only = auto()
 
 
 @dataclass
@@ -18,9 +12,7 @@ class FormatOptions:
     compact: bool = False
     indent_type: IndentType = field(default_factory=lambda: IndentType.NONE())
     text_style: TextStyle = field(default_factory=TextStyle)
-    apply_text_style_to: ApplyTextStyleTo = (
-        ApplyTextStyleTo.all,
-    )  # TODO: add proper handling in PrettyFormatter
+    text_style_full: bool = False
     projections: Optional[TypeProjectionFuncMapping] = None
     formatters: Optional[TypeFormatterFuncSequence] = None
 

--- a/src/pformat/indentation_utility.py
+++ b/src/pformat/indentation_utility.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from typing import Optional
+
+from .text_style import apply_style
 
 DEFAULT_INDENT_CHARACTER = " "
 DEFAULT_INDENT_WIDTH = 4
@@ -23,15 +26,13 @@ class IndentMarker:
 class IndentType:
     width: int = DEFAULT_INDENT_WIDTH
     marker: IndentMarker = field(default_factory=IndentMarker)
+    style: Optional[str] = None
 
     def size(self, depth: int) -> int:
         return self.width * depth
 
     def string(self, depth: int) -> str:
-        if self.marker.fill:
-            return self.marker.character * self.size(depth)
-
-        return f"{self.marker.character}{DEFAULT_INDENT_CHARACTER * (self.width - 1)}" * depth
+        return apply_style(self.__string(depth), self.style)
 
     def add_to(self, s: str, depth: int = 1) -> str:
         return f"{self.string(depth)}{s}"
@@ -39,47 +40,71 @@ class IndentType:
     def add_to_each(self, s_collection: Iterable[str], depth: int = 1) -> list[str]:
         return [self.add_to(s, depth) for s in s_collection]
 
+    def __string(self, depth: int) -> str:
+        if self.marker.fill:
+            return self.marker.character * self.size(depth)
+
+        return f"{self.marker.character}{DEFAULT_INDENT_CHARACTER * (self.width - 1)}" * depth
+
     @staticmethod
     def new(
         width: int = DEFAULT_INDENT_WIDTH,
         character: str = DEFAULT_INDENT_CHARACTER,
         fill: bool = True,
+        style: Optional[str] = None,
     ) -> IndentType:
         return IndentType(
             width=width,
             marker=IndentMarker(character=character, fill=fill),
+            style=style,
         )
 
     @staticmethod
     def NONE(width: int = DEFAULT_INDENT_WIDTH) -> IndentType:
-        return IndentType.new(width=width)
+        return IndentType.new(width=width, style=None)
 
     @staticmethod
-    def DOTS(width: int = DEFAULT_INDENT_WIDTH) -> IndentType:
+    def DOTS(
+        width: int = DEFAULT_INDENT_WIDTH,
+        style: Optional[str] = None,
+    ) -> IndentType:
         return IndentType.new(
             width=width,
             character="·",
+            style=style,
         )
 
     @staticmethod
-    def THICK_DOTS(width: int = DEFAULT_INDENT_WIDTH) -> "IndentType":
+    def THICK_DOTS(
+        width: int = DEFAULT_INDENT_WIDTH,
+        style: Optional[str] = None,
+    ) -> "IndentType":
         return IndentType.new(
             width=width,
             character="•",
+            style=style,
         )
 
     @staticmethod
-    def LINE(width: int = DEFAULT_INDENT_WIDTH) -> "IndentType":
+    def LINE(
+        width: int = DEFAULT_INDENT_WIDTH,
+        style: Optional[str] = None,
+    ) -> "IndentType":
         return IndentType.new(
             width=width,
             character="|",
             fill=False,
+            style=style,
         )
 
     @staticmethod
-    def BROKEN_BAR(width: int = DEFAULT_INDENT_WIDTH) -> "IndentType":
+    def BROKEN_BAR(
+        width: int = DEFAULT_INDENT_WIDTH,
+        style: Optional[str] = None,
+    ) -> "IndentType":
         return IndentType.new(
             width=width,
             character="¦",
             fill=False,
+            style=style,
         )

--- a/src/pformat/indentation_utility.py
+++ b/src/pformat/indentation_utility.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Optional
 
-from .text_style import apply_style
+from .text_style import TextStyle, TextStyleParam
 
 DEFAULT_INDENT_CHARACTER = " "
 DEFAULT_INDENT_WIDTH = 4
@@ -26,13 +25,17 @@ class IndentMarker:
 class IndentType:
     width: int = DEFAULT_INDENT_WIDTH
     marker: IndentMarker = field(default_factory=IndentMarker)
-    style: Optional[str] = None
+    style: TextStyle = field(default_factory=TextStyle)
 
-    def size(self, depth: int) -> int:
+    def __post_init__(self):
+        if not isinstance(self.style, TextStyle):
+            self.style = TextStyle.new(self.style)
+
+    def length(self, depth: int) -> int:
         return self.width * depth
 
     def string(self, depth: int) -> str:
-        return apply_style(self.__string(depth), self.style)
+        return self.style.apply_to(self.__string(depth))
 
     def add_to(self, s: str, depth: int = 1) -> str:
         return f"{self.string(depth)}{s}"
@@ -42,7 +45,7 @@ class IndentType:
 
     def __string(self, depth: int) -> str:
         if self.marker.fill:
-            return self.marker.character * self.size(depth)
+            return self.marker.character * self.length(depth)
 
         return f"{self.marker.character}{DEFAULT_INDENT_CHARACTER * (self.width - 1)}" * depth
 
@@ -51,7 +54,7 @@ class IndentType:
         width: int = DEFAULT_INDENT_WIDTH,
         character: str = DEFAULT_INDENT_CHARACTER,
         fill: bool = True,
-        style: Optional[str] = None,
+        style: TextStyleParam = None,
     ) -> IndentType:
         return IndentType(
             width=width,
@@ -66,7 +69,7 @@ class IndentType:
     @staticmethod
     def DOTS(
         width: int = DEFAULT_INDENT_WIDTH,
-        style: Optional[str] = None,
+        style: TextStyleParam = None,
     ) -> IndentType:
         return IndentType.new(
             width=width,
@@ -77,7 +80,7 @@ class IndentType:
     @staticmethod
     def THICK_DOTS(
         width: int = DEFAULT_INDENT_WIDTH,
-        style: Optional[str] = None,
+        style: TextStyleParam = None,
     ) -> "IndentType":
         return IndentType.new(
             width=width,
@@ -88,7 +91,7 @@ class IndentType:
     @staticmethod
     def LINE(
         width: int = DEFAULT_INDENT_WIDTH,
-        style: Optional[str] = None,
+        style: TextStyleParam = None,
     ) -> "IndentType":
         return IndentType.new(
             width=width,
@@ -100,7 +103,7 @@ class IndentType:
     @staticmethod
     def BROKEN_BAR(
         width: int = DEFAULT_INDENT_WIDTH,
-        style: Optional[str] = None,
+        style: TextStyleParam = None,
     ) -> "IndentType":
         return IndentType.new(
             width=width,

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -10,7 +10,7 @@ from .format_options import (
     TypeProjectionFuncMapping,
 )
 from .formatter_types import MultilineFormatter, NormalFormatter, TypeFormatter
-from .text_style import TextStyle, TextStyleParam, _strlen_clean
+from .text_style import TextStyle, TextStyleParam, strlen_no_style
 
 
 class PrettyFormatter:
@@ -118,7 +118,7 @@ class IterableFormatter(MultilineFormatter):
             collecion_str = (
                 opening + ", ".join(self._base_formatter(value) for value in collection) + closing
             )
-            collecion_str_len = _strlen_clean(collecion_str) + self._options.indent_type.length(
+            collecion_str_len = strlen_no_style(collecion_str) + self._options.indent_type.length(
                 depth
             )
             if self._options.width is None or collecion_str_len <= self._options.width:
@@ -170,7 +170,7 @@ class MappingFormatter(MultilineFormatter):
                 )
                 + "}"
             )
-            mapping_str_len = _strlen_clean(mapping_str) + self._options.indent_type.length(depth)
+            mapping_str_len = strlen_no_style(mapping_str) + self._options.indent_type.length(depth)
             if self._options.width is None or mapping_str_len <= self._options.width:
                 if self._options.text_style_full:
                     return [self._options.text_style.apply_to(mapping_str)]

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -33,8 +33,7 @@ class PrettyFormatter:
         compact: int = FormatOptions.default("compact"),
         indent_type: int = FormatOptions.default("indent_type"),
         text_style: TextStyleParam = FormatOptions.default("text_style"),
-        # apply_text_style_to: ApplyTextStyleTo = FormatOptions.default("apply_text_style_to"),
-        text_style_full: bool = FormatOptions.default("text_style_full"),
+        style_entire_text: bool = FormatOptions.default("style_entire_text"),
         projections: Optional[TypeProjectionFuncMapping] = FormatOptions.default("projections"),
         formatters: Optional[TypeFormatterFuncSequence] = FormatOptions.default("formatters"),
     ) -> PrettyFormatter:
@@ -44,7 +43,7 @@ class PrettyFormatter:
                 compact=compact,
                 indent_type=indent_type,
                 text_style=TextStyle.new(text_style),
-                text_style_full=text_style_full,
+                style_entire_text=style_entire_text,
                 projections=projections,
                 formatters=formatters,
             )
@@ -122,7 +121,7 @@ class IterableFormatter(MultilineFormatter):
                 depth
             )
             if self._options.width is None or collecion_str_len <= self._options.width:
-                if self._options.text_style_full:
+                if self._options.style_entire_text:
                     return [self._options.text_style.apply_to(collecion_str)]
                 return [collecion_str]
 
@@ -133,7 +132,7 @@ class IterableFormatter(MultilineFormatter):
             values.extend(v_fmt)
 
         values_fmt = self._options.indent_type.add_to_each(values)
-        if self._options.text_style_full:
+        if self._options.style_entire_text:
             return self._options.text_style.apply_to_each([opening, *values_fmt, closing])
         return [opening, *values_fmt, closing]
 
@@ -172,7 +171,7 @@ class MappingFormatter(MultilineFormatter):
             )
             mapping_str_len = strlen_no_style(mapping_str) + self._options.indent_type.length(depth)
             if self._options.width is None or mapping_str_len <= self._options.width:
-                if self._options.text_style_full:
+                if self._options.style_entire_text:
                     return [self._options.text_style.apply_to(mapping_str)]
                 return [mapping_str]
 
@@ -185,6 +184,6 @@ class MappingFormatter(MultilineFormatter):
             values.extend(item_values_fmt)
 
         values_fmt = self._options.indent_type.add_to_each(values)
-        if self._options.text_style_full:
+        if self._options.style_entire_text:
             return self._options.text_style.apply_to_each(["{", *values_fmt, "}"])
         return ["{", *values_fmt, "}"]

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -4,8 +4,14 @@ from collections import deque
 from collections.abc import Iterable, Mapping
 from typing import Any, Optional
 
-from .format_options import FormatOptions, TypeFormatterFuncSequence, TypeProjectionFuncMapping
+from .format_options import (
+    ApplyTextStyleTo,
+    FormatOptions,
+    TypeFormatterFuncSequence,
+    TypeProjectionFuncMapping,
+)
 from .formatter_types import MultilineFormatter, NormalFormatter, TypeFormatter
+from .text_style import TextStyle, TextStyleParam, _strlen_clean
 
 
 class PrettyFormatter:
@@ -20,13 +26,15 @@ class PrettyFormatter:
             if formatter not in self._formatters:
                 self._formatters.append(formatter)
 
-        self._default_formatter = DefaultFormatter()
+        self._default_formatter = DefaultFormatter(text_style=self._options.text_style)
 
     @staticmethod
     def new(
         width: int = FormatOptions.default("width"),
         compact: int = FormatOptions.default("compact"),
         indent_type: int = FormatOptions.default("indent_type"),
+        text_style: TextStyleParam = FormatOptions.default("text_style"),
+        apply_text_style_to: ApplyTextStyleTo = FormatOptions.default("apply_text_style_to"),
         projections: Optional[TypeProjectionFuncMapping] = FormatOptions.default("projections"),
         formatters: Optional[TypeFormatterFuncSequence] = FormatOptions.default("formatters"),
     ) -> PrettyFormatter:
@@ -35,6 +43,8 @@ class PrettyFormatter:
                 width=width,
                 compact=compact,
                 indent_type=indent_type,
+                text_style=TextStyle.new(text_style),
+                apply_text_style_to=apply_text_style_to,
                 projections=projections,
                 formatters=formatters,
             )
@@ -73,23 +83,24 @@ class PrettyFormatter:
 
     def __predefined_formatters(self) -> list[TypeFormatter]:
         return [
-            DefaultFormatter(str),
-            DefaultFormatter(bytes),
-            DefaultFormatter(bytearray),
+            DefaultFormatter(str, self._options.text_style),
+            DefaultFormatter(bytes, self._options.text_style),
+            DefaultFormatter(bytearray, self._options.text_style),
             MappingFormatter(self),
             IterableFormatter(self),
         ]
 
 
 class DefaultFormatter(NormalFormatter):
-    def __init__(self, t: type = Any):
+    def __init__(self, t: type = Any, text_style: TextStyleParam = None):
         super().__init__(t)
+        self._text_style = TextStyle.new(text_style)
 
     def __call__(self, obj: Any, depth: int = 0) -> str:
         if self.type is not Any:
             self._check_type(obj)
 
-        return repr(obj)
+        return self._text_style.apply_to(repr(obj))
 
 
 class IterableFormatter(MultilineFormatter):
@@ -107,8 +118,11 @@ class IterableFormatter(MultilineFormatter):
             collecion_str = (
                 opening + ", ".join(self._base_formatter(value) for value in collection) + closing
             )
-            collecion_str_len = len(collecion_str) + self._options.indent_type.size(depth)
+            collecion_str_len = _strlen_clean(collecion_str) + self._options.indent_type.length(
+                depth
+            )
             if self._options.width is None or collecion_str_len <= self._options.width:
+                # return [self._options.text_style.apply_to(collecion_str)]
                 return [collecion_str]
 
         values = list()
@@ -118,6 +132,7 @@ class IterableFormatter(MultilineFormatter):
             values.extend(v_fmt)
 
         values_fmt = self._options.indent_type.add_to_each(values)
+        # return self._options.text_style.apply_to_each([opening, *values_fmt, closing])
         return [opening, *values_fmt, closing]
 
     @staticmethod
@@ -153,8 +168,9 @@ class MappingFormatter(MultilineFormatter):
                 )
                 + "}"
             )
-            collecion_str_len = len(mapping_str) + self._options.indent_type.size(depth)
-            if self._options.width is None or collecion_str_len <= self._options.width:
+            mapping_str_len = _strlen_clean(mapping_str) + self._options.indent_type.length(depth)
+            if self._options.width is None or mapping_str_len <= self._options.width:
+                # return [self._options.text_style.apply_to(mapping_str)]
                 return [mapping_str]
 
         values = list()
@@ -166,4 +182,5 @@ class MappingFormatter(MultilineFormatter):
             values.extend(item_values_fmt)
 
         values_fmt = self._options.indent_type.add_to_each(values)
+        # return self._options.text_style.apply_to_each(["{", *values_fmt, "}"])
         return ["{", *values_fmt, "}"]

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -5,7 +5,6 @@ from collections.abc import Iterable, Mapping
 from typing import Any, Optional
 
 from .format_options import (
-    ApplyTextStyleTo,
     FormatOptions,
     TypeFormatterFuncSequence,
     TypeProjectionFuncMapping,
@@ -34,7 +33,8 @@ class PrettyFormatter:
         compact: int = FormatOptions.default("compact"),
         indent_type: int = FormatOptions.default("indent_type"),
         text_style: TextStyleParam = FormatOptions.default("text_style"),
-        apply_text_style_to: ApplyTextStyleTo = FormatOptions.default("apply_text_style_to"),
+        # apply_text_style_to: ApplyTextStyleTo = FormatOptions.default("apply_text_style_to"),
+        text_style_full: bool = FormatOptions.default("text_style_full"),
         projections: Optional[TypeProjectionFuncMapping] = FormatOptions.default("projections"),
         formatters: Optional[TypeFormatterFuncSequence] = FormatOptions.default("formatters"),
     ) -> PrettyFormatter:
@@ -44,7 +44,7 @@ class PrettyFormatter:
                 compact=compact,
                 indent_type=indent_type,
                 text_style=TextStyle.new(text_style),
-                apply_text_style_to=apply_text_style_to,
+                text_style_full=text_style_full,
                 projections=projections,
                 formatters=formatters,
             )
@@ -122,7 +122,8 @@ class IterableFormatter(MultilineFormatter):
                 depth
             )
             if self._options.width is None or collecion_str_len <= self._options.width:
-                # return [self._options.text_style.apply_to(collecion_str)]
+                if self._options.text_style_full:
+                    return [self._options.text_style.apply_to(collecion_str)]
                 return [collecion_str]
 
         values = list()
@@ -132,7 +133,8 @@ class IterableFormatter(MultilineFormatter):
             values.extend(v_fmt)
 
         values_fmt = self._options.indent_type.add_to_each(values)
-        # return self._options.text_style.apply_to_each([opening, *values_fmt, closing])
+        if self._options.text_style_full:
+            return self._options.text_style.apply_to_each([opening, *values_fmt, closing])
         return [opening, *values_fmt, closing]
 
     @staticmethod
@@ -170,7 +172,8 @@ class MappingFormatter(MultilineFormatter):
             )
             mapping_str_len = _strlen_clean(mapping_str) + self._options.indent_type.length(depth)
             if self._options.width is None or mapping_str_len <= self._options.width:
-                # return [self._options.text_style.apply_to(mapping_str)]
+                if self._options.text_style_full:
+                    return [self._options.text_style.apply_to(mapping_str)]
                 return [mapping_str]
 
         values = list()
@@ -182,5 +185,6 @@ class MappingFormatter(MultilineFormatter):
             values.extend(item_values_fmt)
 
         values_fmt = self._options.indent_type.add_to_each(values)
-        # return self._options.text_style.apply_to_each(["{", *values_fmt, "}"])
+        if self._options.text_style_full:
+            return self._options.text_style.apply_to_each(["{", *values_fmt, "}"])
         return ["{", *values_fmt, "}"]

--- a/src/pformat/text_style.py
+++ b/src/pformat/text_style.py
@@ -21,16 +21,16 @@ def _strlen_clean(s: str) -> int:
 
 
 def _apply_style_normal(s: str, style: str) -> str:
-    return f"{style}{s}{Style.reset}"
+    return f"{Style.reset}{style}{s}{Style.reset}"
 
 
 def _apply_style_override(s: str, style: str) -> str:
-    return f"{style}{_clean_style(s)}{Style.reset}"
+    return f"{Style.reset}{style}{_clean_style(s)}{Style.reset}"
 
 
 def _apply_style_preserve(s: str, style: str) -> str:
-    s_aligned = re.sub(ANSI_ESCAPE_RESET_PATTERN, style, s)
-    return f"{style}{s_aligned}{Style.reset}"
+    s_aligned = re.sub(ANSI_ESCAPE_RESET_PATTERN, f"{Style.reset}{style}", s)
+    return f"{Style.reset}{style}{s_aligned}{Style.reset}"
 
 
 TextStyleValue = Optional[str]

--- a/src/pformat/text_style.py
+++ b/src/pformat/text_style.py
@@ -1,10 +1,64 @@
-from typing import Optional
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Union
 
 from colored import Style
 
+ANSI_ESCAPE_PATTERN = r"\x1b\[[0-9;]*[mGK]"
+ANSI_ESCAPE_RESET_PATTERN = re.escape(Style.reset)
 
-def apply_style(s: str, style: Optional[str]) -> str:
-    if style is None:
-        return s
 
+def _clean_style(s: str) -> str:
+    return re.sub(ANSI_ESCAPE_PATTERN, "", s)
+
+
+def _strlen_clean(s: str) -> int:
+    return len(_clean_style(s))
+
+
+def _apply_style_normal(s: str, style: str) -> str:
     return f"{style}{s}{Style.reset}"
+
+
+def _apply_style_override(s: str, style: str) -> str:
+    return f"{style}{_clean_style(s)}{Style.reset}"
+
+
+def _apply_style_preserve(s: str, style: str) -> str:
+    s_aligned = re.sub(ANSI_ESCAPE_RESET_PATTERN, style, s)
+    return f"{style}{s_aligned}{Style.reset}"
+
+
+TextStyleValue = Optional[str]
+TextStyleParam = Union["TextStyle", TextStyleValue]
+
+
+@dataclass
+class TextStyle:
+    class Mode(Enum):
+        normal = _apply_style_normal
+        override = _apply_style_override
+        preserve = _apply_style_preserve
+
+    value: TextStyleValue = None
+    mode: Mode = Mode.preserve
+
+    def apply_to(self, s: str) -> str:
+        if self.value is None:
+            return s
+
+        return self.mode(s, self.value)
+
+    def apply_to_each(self, s_collection: Iterable[str]) -> list[str]:
+        return [self.apply_to(s) for s in s_collection]
+
+    @staticmethod
+    def new(style: TextStyleParam) -> TextStyle:
+        if style is None:
+            return TextStyle()
+
+        return TextStyle(style) if isinstance(style, str) else style

--- a/src/pformat/text_style.py
+++ b/src/pformat/text_style.py
@@ -12,12 +12,12 @@ ANSI_ESCAPE_PATTERN = r"\x1b\[[0-9;]*[mGK]"
 ANSI_ESCAPE_RESET_PATTERN = re.escape(Style.reset)
 
 
-def _clean_style(s: str) -> str:
+def rm_style_modifiers(s: str) -> str:
     return re.sub(ANSI_ESCAPE_PATTERN, "", s)
 
 
-def _strlen_clean(s: str) -> int:
-    return len(_clean_style(s))
+def strlen_no_style(s: str) -> int:
+    return len(rm_style_modifiers(s))
 
 
 def _apply_style_normal(s: str, style: str) -> str:
@@ -25,7 +25,7 @@ def _apply_style_normal(s: str, style: str) -> str:
 
 
 def _apply_style_override(s: str, style: str) -> str:
-    return f"{Style.reset}{style}{_clean_style(s)}{Style.reset}"
+    return f"{Style.reset}{style}{rm_style_modifiers(s)}{Style.reset}"
 
 
 def _apply_style_preserve(s: str, style: str) -> str:
@@ -40,6 +40,8 @@ TextStyleParam = Union["TextStyle", TextStyleValue]
 @dataclass
 class TextStyle:
     class Mode(Enum):
+        # TODO: ._value_ -> name, .apply -> callback
+
         normal = _apply_style_normal
         override = _apply_style_override
         preserve = _apply_style_preserve

--- a/src/pformat/text_style.py
+++ b/src/pformat/text_style.py
@@ -1,0 +1,10 @@
+from typing import Optional
+
+from colored import Style
+
+
+def apply_style(s: str, style: Optional[str]) -> str:
+    if style is None:
+        return s
+
+    return f"{style}{s}{Style.reset}"

--- a/test/test_dummy.py
+++ b/test/test_dummy.py
@@ -1,3 +1,4 @@
+from colored import Fore
 from icecream import ic
 
 from pformat import FormatOptions, IndentType, PrettyFormatter, normal_formatter
@@ -10,22 +11,22 @@ the behaviour of PrettyFormatter
 
 FMT_OPTIONS = {
     "default": FormatOptions(),
-    "compact, dot indent": FormatOptions(
+    "compact, dot indent (dark_gray)": FormatOptions(
         width=40,
         compact=True,
-        indent_type=IndentType.DOTS(width=3),
+        indent_type=IndentType.DOTS(width=3, style=Fore.dark_gray),
     ),
-    "compact, bbar indent, projections": FormatOptions(
+    "compact, bbar indent (grey_37), projections": FormatOptions(
         width=40,
         compact=True,
-        indent_type=IndentType.BROKEN_BAR(),
+        indent_type=IndentType.BROKEN_BAR(style=Fore.grey_37),
         projections={
             float: lambda f: int(f),
             bytes: lambda b: bytearray(b),
         },
     ),
-    "line indent, formatters": FormatOptions(
-        indent_type=IndentType.LINE(),
+    "line indent (green), formatters": FormatOptions(
+        indent_type=IndentType.LINE(style=Fore.green),
         formatters=[
             normal_formatter(int, lambda i, _: f"{i:.1f}"),
             normal_formatter(float, lambda f, _: f"{f:.2f}"),

--- a/test/test_dummy.py
+++ b/test/test_dummy.py
@@ -11,10 +11,11 @@ the behaviour of PrettyFormatter
 
 FMT_OPTIONS = {
     "default": FormatOptions(),
-    "compact, dot indent (dark_gray)": FormatOptions(
+    "compact, dot indent (dark_gray), Fore.green": FormatOptions(
         width=40,
         compact=True,
         indent_type=IndentType.DOTS(width=3, style=Fore.dark_gray),
+        text_style=f"{Fore.green}",
     ),
     "compact, bbar indent (grey_37), projections": FormatOptions(
         width=40,
@@ -75,6 +76,6 @@ def test_dummy_mapping():
     print("\n" + ("-" * 50) + "\n")
 
     for config_name, fmt_opt in FMT_OPTIONS.items():
-        ic(config_name, fmt_opt)
+        ic(config_name)
         fmt = PrettyFormatter(fmt_opt)
         print(fmt(mapping), end="\n" * 3)

--- a/test/test_dummy.py
+++ b/test/test_dummy.py
@@ -77,6 +77,6 @@ def test_dummy_mapping():
     print("\n" + ("-" * 50) + "\n")
 
     for config_name, fmt_opt in FMT_OPTIONS.items():
-        ic(config_name)
+        ic(config_name, fmt_opt)
         fmt = PrettyFormatter(fmt_opt)
         print(fmt(mapping), end="\n" * 3)

--- a/test/test_dummy.py
+++ b/test/test_dummy.py
@@ -1,4 +1,4 @@
-from colored import Fore
+from colored import Back, Fore, Style
 from icecream import ic
 
 from pformat import FormatOptions, IndentType, PrettyFormatter, normal_formatter
@@ -11,11 +11,12 @@ the behaviour of PrettyFormatter
 
 FMT_OPTIONS = {
     "default": FormatOptions(),
-    "compact, dot indent (dark_gray), Fore.green": FormatOptions(
+    "compact, dot indent (Fore.dark_gray), text_style=Force.green,Back.black,Style.bold,full": FormatOptions(
         width=40,
         compact=True,
         indent_type=IndentType.DOTS(width=3, style=Fore.dark_gray),
-        text_style=f"{Fore.green}",
+        text_style=f"{Fore.green}{Back.black}{Style.bold}",
+        text_style_full=True,
     ),
     "compact, bbar indent (grey_37), projections": FormatOptions(
         width=40,

--- a/test/test_dummy.py
+++ b/test/test_dummy.py
@@ -11,24 +11,27 @@ the behaviour of PrettyFormatter
 
 FMT_OPTIONS = {
     "default": FormatOptions(),
-    "compact, dot indent (Fore.dark_gray), text_style=Force.green,Back.black,Style.bold,full": FormatOptions(
+    "compact, dot indent (Fore.dark_gray), text_style=Force.green,Back.black,Style.bold (enitre)": FormatOptions(
         width=40,
         compact=True,
         indent_type=IndentType.DOTS(width=3, style=Fore.dark_gray),
         text_style=f"{Fore.green}{Back.black}{Style.bold}",
-        text_style_full=True,
+        style_entire_text=True,
     ),
-    "compact, bbar indent (grey_37), projections": FormatOptions(
+    "projections, compact, bbar indent (grey_37), Fore.magenta": FormatOptions(
         width=40,
         compact=True,
         indent_type=IndentType.BROKEN_BAR(style=Fore.grey_37),
+        text_style=Fore.magenta,
         projections={
             float: lambda f: int(f),
             bytes: lambda b: bytearray(b),
         },
     ),
-    "line indent (green), formatters": FormatOptions(
+    "formatters, line indent (Fore.green), Fore.cyan (entire)": FormatOptions(
         indent_type=IndentType.LINE(style=Fore.green),
+        text_style=Fore.cyan,
+        style_entire_text=True,
         formatters=[
             normal_formatter(int, lambda i, _: f"{i:.1f}"),
             normal_formatter(float, lambda f, _: f"{f:.2f}"),
@@ -77,6 +80,6 @@ def test_dummy_mapping():
     print("\n" + ("-" * 50) + "\n")
 
     for config_name, fmt_opt in FMT_OPTIONS.items():
-        ic(config_name, fmt_opt)
+        ic(config_name)
         fmt = PrettyFormatter(fmt_opt)
         print(fmt(mapping), end="\n" * 3)

--- a/test/test_format_options.py
+++ b/test/test_format_options.py
@@ -2,6 +2,12 @@ from dataclasses import asdict, fields
 
 from pformat.format_options import FormatOptions
 from pformat.indentation_utility import IndentType
+from pformat.text_style import TextStyle
+
+
+def test_init_with_none_text_style():
+    sut = FormatOptions(text_style=None)
+    assert sut.text_style == TextStyle()
 
 
 def test_asdict_shallow():

--- a/test/test_indentation_utility.py
+++ b/test/test_indentation_utility.py
@@ -90,16 +90,16 @@ class TestIndentType:
         )
 
     @pytest.mark.parametrize("width,depth", WD_PARAMS, ids=WD_IDS)
-    def test_size(self, width: int, depth: int):
+    def test_length(self, width: int, depth: int):
         sut = IndentType(width=width)
-        assert sut.size(depth) == width * depth
+        assert sut.length(depth) == width * depth
 
     @pytest.mark.parametrize("width,depth", WD_PARAMS, ids=WD_IDS)
     def test_string_fill(self, width: int, depth: int):
         character = "_"
         sut = IndentType.new(width, character=character, fill=True)
 
-        assert sut.string(depth) == character * sut.size(depth)
+        assert sut.string(depth) == character * sut.length(depth)
 
     @pytest.mark.parametrize("width,depth", WD_PARAMS, ids=WD_IDS)
     def test_string_no_fill(self, width: int, depth: int):

--- a/test/test_indentation_utility.py
+++ b/test/test_indentation_utility.py
@@ -58,7 +58,7 @@ class TestIndentType:
     WD_IDS = [f"width={w},depth={d}" for w, d in WD_PARAMS]
 
     @pytest.fixture(params=WM_PARAMS, ids=WM_IDS)
-    def sut(self, request: pytest.FixtureRequest) -> str:
+    def sut(self, request: pytest.FixtureRequest) -> IndentType:
         self.dummy_str = "string"
         self.width, self.marker = request.param
         return IndentType(self.width, self.marker)

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -3,11 +3,13 @@ from collections.abc import Iterable, Mapping
 from itertools import product
 
 import pytest
+from colored import Back, Fore, Style
 
 from pformat.format_options import FormatOptions
 from pformat.formatter_types import normal_formatter
 from pformat.indentation_utility import IndentType
 from pformat.pretty_formatter import IterableFormatter, PrettyFormatter
+from pformat.text_style import TextStyle
 
 
 def test_iterable_formatter_get_parnens():
@@ -285,6 +287,47 @@ class TestPrettyFormatterCompactForNestedMappingTypes:
 
         assert sut(mapping) == expected_output
         assert sut.format(mapping) == expected_output
+
+
+class TestPrettyFormatterTextStyleFull:
+    COMPACT_VALS = [True, False]
+    STYLE_VALS = [Fore.light_gray, Back.green, Style.bold]
+    MODE_VALS = [TextStyle.Mode.normal, TextStyle.Mode.override, TextStyle.Mode.preserve]
+
+    CSM_PARAMS = list(product(COMPACT_VALS, STYLE_VALS, MODE_VALS))
+    CSM_IDS = [f"{compact=},{style=},{mode=}" for compact, style, mode in CSM_PARAMS]
+
+    @pytest.fixture(autouse=True, params=CSM_PARAMS, ids=CSM_IDS)
+    def sut(self, request: pytest.FixtureRequest) -> TextStyle:
+        compact, style, mode = request.param
+        self.text_style = TextStyle(style, mode)
+        return PrettyFormatter.new(
+            compact=compact, text_style=self.text_style, text_style_full=True
+        )
+
+    def _is_str_styled(self, s: str) -> bool:
+        return s.startswith(f"{Style.reset}{self.text_style.value}") and s.endswith(Style.reset)
+
+    def test_is_output_styled_simple(self, sut: PrettyFormatter):
+        assert all(self._is_str_styled(sut(item)) for item in SIMPLE_DATA)
+
+    @pytest.mark.parametrize("iterable_type", RECOGNIZABLE_NHASH_ITERABLE_TYPES)
+    def test_is_output_styled_nested_iterable(self, sut: PrettyFormatter, iterable_type: type):
+        collection = iterable_type([*SIMPLE_HASHABLE_DATA, iterable_type(SIMPLE_HASHABLE_DATA)])
+
+        formatted = sut(collection)
+        formatted_lines = formatted.split("\n")
+
+        assert all(self._is_str_styled(line) for line in formatted_lines)
+
+    def test_is_output_styled_nested_mapping(self, sut: PrettyFormatter):
+        mapping = gen_mapping(SIMPLE_HASHABLE_DATA)
+        mapping["nested"] = gen_mapping(SIMPLE_HASHABLE_DATA)
+
+        formatted = sut(mapping)
+        formatted_lines = formatted.split("\n")
+
+        assert all(self._is_str_styled(line) for line in formatted_lines)
 
 
 class TestPrettyFormatterProjections:

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -289,7 +289,7 @@ class TestPrettyFormatterCompactForNestedMappingTypes:
         assert sut.format(mapping) == expected_output
 
 
-class TestPrettyFormatterTextStyleFull:
+class TestPrettyFormatterStyleEntireText:
     COMPACT_VALS = [True, False]
     STYLE_VALS = [Fore.light_gray, Back.green, Style.bold]
     MODE_VALS = [TextStyle.Mode.normal, TextStyle.Mode.override, TextStyle.Mode.preserve]
@@ -302,7 +302,7 @@ class TestPrettyFormatterTextStyleFull:
         compact, style, mode = request.param
         self.text_style = TextStyle(style, mode)
         return PrettyFormatter.new(
-            compact=compact, text_style=self.text_style, text_style_full=True
+            compact=compact, text_style=self.text_style, style_entire_text=True
         )
 
     def _is_str_styled(self, s: str) -> bool:

--- a/test/test_text_style.py
+++ b/test/test_text_style.py
@@ -1,0 +1,16 @@
+import pytest
+from colored import Back, Fore, Style
+
+from pformat.text_style import apply_style
+
+STR = "string"
+STYLE_VALS = [Fore.light_gray, Back.green, Style.bold]
+
+
+def test_apply_style_with_none_style():
+    assert apply_style(STR, style=None) == STR
+
+
+@pytest.mark.parametrize("style", STYLE_VALS)
+def test_apply_style(style: str):
+    assert apply_style(STR, style) == f"{style}{STR}{Style.reset}"

--- a/test/test_text_style.py
+++ b/test/test_text_style.py
@@ -1,16 +1,80 @@
-# import pytest
-# from colored import Back, Fore, Style
+import re
 
-# from pformat.text_style import apply_style
+import pytest
+from colored import Back, Fore, Style
 
-# STR = "string"
-# STYLE_VALS = [Fore.light_gray, Back.green, Style.bold]
+from pformat.text_style import (
+    ANSI_ESCAPE_RESET_PATTERN,
+    TextStyle,
+    rm_style_modifiers,
+    strlen_no_style,
+)
+
+STYLE_VALS = [Fore.light_gray, Back.green, Style.bold]
+SIMPLE_STR = "string"
+STYLED_STR = SIMPLE_STR.join((STYLE_VALS + [Style.reset]) * 2)
 
 
-# def test_apply_style_with_none_style():
-#     assert apply_style(STR, style=None) == STR
+def test_rm_style_modifiers():
+    s = SIMPLE_STR.join(STYLE_VALS)
+    assert rm_style_modifiers(s) == SIMPLE_STR * (len(STYLE_VALS) - 1)
 
 
-# @pytest.mark.parametrize("style", STYLE_VALS)
-# def test_apply_style(style: str):
-#     assert apply_style(STR, style) == f"{style}{STR}{Style.reset}"
+def test_strlen_no_style():
+    s = SIMPLE_STR.join(STYLE_VALS)
+    assert strlen_no_style(s) == len(SIMPLE_STR) * (len(STYLE_VALS) - 1)
+
+
+class TestTextStyle:
+    MODE_VALS = [TextStyle.Mode.normal, TextStyle.Mode.override, TextStyle.Mode.preserve]
+
+    @pytest.fixture(params=STYLE_VALS, ids=[f"{style=}" for style in STYLE_VALS])
+    def sut(self, request: pytest.FixtureRequest) -> TextStyle:
+        self.style = request.param
+        return TextStyle(self.style)
+
+    def test_apply_to_normal_mode(self, sut: TextStyle):
+        sut.mode = TextStyle.Mode.normal
+        assert sut.apply_to(SIMPLE_STR) == f"{Style.reset}{self.style}{SIMPLE_STR}{Style.reset}"
+
+    def test_apply_to_override_mode(self, sut: TextStyle):
+        sut.mode = TextStyle.Mode.override
+        styled_str = SIMPLE_STR.join(STYLE_VALS)
+
+        assert (
+            sut.apply_to(styled_str)
+            == f"{Style.reset}{self.style}{rm_style_modifiers(styled_str)}{Style.reset}"
+        )
+
+    def test_apply_to_preserve_mode(self, sut: TextStyle):
+        sut.mode = TextStyle.Mode.preserve
+
+        expected_styled_str = re.sub(
+            ANSI_ESCAPE_RESET_PATTERN, f"{Style.reset}{self.style}", STYLED_STR
+        )
+        expected_styled_str = f"{Style.reset}{self.style}{expected_styled_str}{Style.reset}"
+
+        assert sut.apply_to(STYLED_STR) == expected_styled_str
+
+    @pytest.mark.parametrize("mode", MODE_VALS, ids=[f"{mode=}" for mode in MODE_VALS])
+    def test_apply_to_each(self, sut: TextStyle, mode: TextStyle.Mode):
+        empty_collection = list()
+        assert len(sut.apply_to_each(empty_collection)) == 0
+
+        s_collection = [STYLED_STR for _ in range(5)]
+        expected_styled_str = sut.apply_to(STYLED_STR)
+        assert all(s_out == expected_styled_str for s_out in sut.apply_to_each(s_collection))
+
+    def test_new_with_none_style(self):
+        assert TextStyle.new(None) == TextStyle()
+
+    @pytest.mark.parametrize("style", STYLE_VALS, ids=[f"{style=}" for style in STYLE_VALS])
+    def test_new_with_style_str(self, style: str):
+        assert TextStyle.new(style) == TextStyle(style)
+
+    @pytest.mark.parametrize("mode", MODE_VALS, ids=[f"{mode=}" for mode in MODE_VALS])
+    def test_new_with_text_style(self, mode: TextStyle.Mode):
+        style_value = "".join(STYLE_VALS)
+        style = TextStyle(style_value, mode)
+
+        assert TextStyle.new(style) == style

--- a/test/test_text_style.py
+++ b/test/test_text_style.py
@@ -1,16 +1,16 @@
-import pytest
-from colored import Back, Fore, Style
+# import pytest
+# from colored import Back, Fore, Style
 
-from pformat.text_style import apply_style
+# from pformat.text_style import apply_style
 
-STR = "string"
-STYLE_VALS = [Fore.light_gray, Back.green, Style.bold]
-
-
-def test_apply_style_with_none_style():
-    assert apply_style(STR, style=None) == STR
+# STR = "string"
+# STYLE_VALS = [Fore.light_gray, Back.green, Style.bold]
 
 
-@pytest.mark.parametrize("style", STYLE_VALS)
-def test_apply_style(style: str):
-    assert apply_style(STR, style) == f"{style}{STR}{Style.reset}"
+# def test_apply_style_with_none_style():
+#     assert apply_style(STR, style=None) == STR
+
+
+# @pytest.mark.parametrize("style", STYLE_VALS)
+# def test_apply_style(style: str):
+#     assert apply_style(STR, style) == f"{style}{STR}{Style.reset}"


### PR DESCRIPTION
- Added the `colored` dependency
- Added the `TextStyle` class and related utility
- Extended the `IndentType` class with a `style` attribute
- Extended the `FormatOptions` and `PrettyFormatter` classes with the `text_style` and `style_entire_text` attributes