### PR TITLE
YT-PYPF-7: Add the type matching method option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ Python pretty formatting package
   - (important/caution) using projections:
     - don't project a type onto a list of the same type - infinite recursion
     - `text_style` may/will not be applied for custom-formatted types with `style_entire_text=False`
+- Remove the `PrettyFormatter.new` and `FormatOptions.default` methods ?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypformat"
-version = "0.7"
+version = "0.8"
 description = "Python pretty formatting package"
 authors = [
   {name = "SpectraL519"}

--- a/src/pformat/__init__.py
+++ b/src/pformat/__init__.py
@@ -1,7 +1,7 @@
 from .common_types import (
     MultilineTypeFormatterFunc,
     NormalTypeFormatterFunc,
-    TypeFormatterFuncSequence,
+    TypeFormatterFuncMutSequence,
     TypeProjectionFunc,
     TypeProjectionFuncMapping,
 )

--- a/src/pformat/common_types.py
+++ b/src/pformat/common_types.py
@@ -1,11 +1,11 @@
-from collections.abc import Mapping, MutableSequence
+from collections.abc import Iterable, Mapping, MutableSequence
 from typing import Any, Callable, Union
 
 TypeProjectionFunc = Callable[[object], Any]
 TypeProjectionFuncMapping = Mapping[type, TypeProjectionFunc]
 
 NormalTypeFormatterFunc = Callable[[object, int], str]
-MultilineTypeFormatterFunc = Callable[[object, int], str]
-TypeFormatterFuncSequence = MutableSequence[
+MultilineTypeFormatterFunc = Callable[[object, int], Iterable[str]]
+TypeFormatterFuncMutSequence = MutableSequence[
     type, Union[NormalTypeFormatterFunc, MultilineTypeFormatterFunc]
 ]

--- a/src/pformat/format_options.py
+++ b/src/pformat/format_options.py
@@ -13,7 +13,7 @@ class FormatOptions:
     indent_type: IndentType = field(default_factory=lambda: IndentType.NONE())
     text_style: TextStyle = field(default_factory=TextStyle)
     style_entire_text: bool = False
-    # match_strict_types
+    strict_type_matching: bool = False
     projections: Optional[TypeProjectionFuncMapping] = None
     formatters: Optional[TypeFormatterFuncMutSequence] = None
 

--- a/src/pformat/format_options.py
+++ b/src/pformat/format_options.py
@@ -1,7 +1,7 @@
 from dataclasses import MISSING, asdict, dataclass, field, fields
 from typing import Any, Optional
 
-from .common_types import TypeFormatterFuncSequence, TypeProjectionFuncMapping
+from .common_types import TypeFormatterFuncMutSequence, TypeProjectionFuncMapping
 from .indentation_utility import IndentType
 from .text_style import TextStyle
 
@@ -13,8 +13,9 @@ class FormatOptions:
     indent_type: IndentType = field(default_factory=lambda: IndentType.NONE())
     text_style: TextStyle = field(default_factory=TextStyle)
     style_entire_text: bool = False
+    # match_strict_types
     projections: Optional[TypeProjectionFuncMapping] = None
-    formatters: Optional[TypeFormatterFuncSequence] = None
+    formatters: Optional[TypeFormatterFuncMutSequence] = None
 
     def __post_init__(self):
         if not isinstance(self.text_style, TextStyle):

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -6,7 +6,7 @@ from typing import Any, Optional
 
 from .format_options import (
     FormatOptions,
-    TypeFormatterFuncSequence,
+    TypeFormatterFuncMutSequence,
     TypeProjectionFuncMapping,
 )
 from .formatter_types import MultilineFormatter, NormalFormatter, TypeFormatter
@@ -35,7 +35,7 @@ class PrettyFormatter:
         text_style: TextStyleParam = FormatOptions.default("text_style"),
         style_entire_text: bool = FormatOptions.default("style_entire_text"),
         projections: Optional[TypeProjectionFuncMapping] = FormatOptions.default("projections"),
-        formatters: Optional[TypeFormatterFuncSequence] = FormatOptions.default("formatters"),
+        formatters: Optional[TypeFormatterFuncMutSequence] = FormatOptions.default("formatters"),
     ) -> PrettyFormatter:
         return PrettyFormatter(
             options=FormatOptions(
@@ -59,7 +59,7 @@ class PrettyFormatter:
         projected_obj = self._project(obj)
 
         for formatter in self._formatters:
-            if formatter.is_valid(projected_obj):
+            if formatter.has_valid_type(projected_obj):
                 return self._format_with(projected_obj, formatter, depth)
 
         return self._format_with(projected_obj, self._default_formatter, depth)

--- a/src/pformat/pretty_formatter.py
+++ b/src/pformat/pretty_formatter.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from collections import deque
+from collections import ChainMap, OrderedDict, defaultdict, deque
 from collections.abc import Iterable, Mapping
-from typing import Any, Optional
+from types import MappingProxyType
+from typing import Any, Optional, Union
 
 from .format_options import (
     FormatOptions,
@@ -34,6 +35,7 @@ class PrettyFormatter:
         indent_type: int = FormatOptions.default("indent_type"),
         text_style: TextStyleParam = FormatOptions.default("text_style"),
         style_entire_text: bool = FormatOptions.default("style_entire_text"),
+        strict_type_matching: bool = FormatOptions.default("strict_type_matching"),
         projections: Optional[TypeProjectionFuncMapping] = FormatOptions.default("projections"),
         formatters: Optional[TypeFormatterFuncMutSequence] = FormatOptions.default("formatters"),
     ) -> PrettyFormatter:
@@ -44,6 +46,7 @@ class PrettyFormatter:
                 indent_type=indent_type,
                 text_style=TextStyle.new(text_style),
                 style_entire_text=style_entire_text,
+                strict_type_matching=strict_type_matching,
                 projections=projections,
                 formatters=formatters,
             )
@@ -59,7 +62,7 @@ class PrettyFormatter:
         projected_obj = self._project(obj)
 
         for formatter in self._formatters:
-            if formatter.has_valid_type(projected_obj):
+            if formatter.has_valid_type(projected_obj, self._options.strict_type_matching):
                 return self._format_with(projected_obj, formatter, depth)
 
         return self._format_with(projected_obj, self._default_formatter, depth)
@@ -103,10 +106,16 @@ class DefaultFormatter(NormalFormatter):
 
 
 class IterableFormatter(MultilineFormatter):
+    _TYPES = Union[list, set, frozenset, tuple, range, deque, memoryview]
+
     def __init__(self, base_formatter: PrettyFormatter):
-        super().__init__(Iterable)
         self._base_formatter = base_formatter
         self._options = self._base_formatter._options
+
+        if self._options.strict_type_matching:
+            super().__init__(IterableFormatter._TYPES)
+        else:
+            super().__init__(Iterable)
 
     def __call__(self, collection: Iterable, depth: int = 0) -> list[str]:
         self._check_type(collection)
@@ -152,10 +161,16 @@ class IterableFormatter(MultilineFormatter):
 
 
 class MappingFormatter(MultilineFormatter):
+    _TYPES = Union[dict, defaultdict, OrderedDict, MappingProxyType, ChainMap]
+
     def __init__(self, base_formatter: PrettyFormatter):
-        super().__init__(Mapping)
         self._base_formatter = base_formatter
         self._options = self._base_formatter._options
+
+        if self._options.strict_type_matching:
+            super().__init__(MappingFormatter._TYPES)
+        else:
+            super().__init__(Mapping)
 
     def __call__(self, mapping: Mapping, depth: int = 0) -> list[str]:
         self._check_type(mapping)

--- a/test/test_dummy.py
+++ b/test/test_dummy.py
@@ -1,4 +1,4 @@
-from colored import Back, Fore, Style
+from colored import Fore, Style
 from icecream import ic
 
 from pformat import FormatOptions, IndentType, PrettyFormatter, normal_formatter
@@ -15,7 +15,7 @@ FMT_OPTIONS = {
         width=40,
         compact=True,
         indent_type=IndentType.DOTS(width=3, style=Fore.dark_gray),
-        text_style=f"{Fore.green}{Back.black}{Style.bold}",
+        text_style=f"{Fore.green}{Style.bold}",
         style_entire_text=True,
     ),
     "projections, compact, bbar indent (grey_37), Fore.magenta": FormatOptions(
@@ -56,6 +56,7 @@ def test_dummy_collection():
     ]
 
     ic(collection)
+    print(f"{collection = }")
     print("\n" + ("-" * 50) + "\n")
 
     for config_name, fmt_opt in FMT_OPTIONS.items():
@@ -77,6 +78,7 @@ def test_dummy_mapping():
     }
 
     ic(mapping)
+    print(f"{mapping = }")
     print("\n" + ("-" * 50) + "\n")
 
     for config_name, fmt_opt in FMT_OPTIONS.items():

--- a/test/test_format_options.py
+++ b/test/test_format_options.py
@@ -5,6 +5,17 @@ from pformat.indentation_utility import IndentType
 from pformat.text_style import TextStyle
 
 
+def test_default():
+    assert FormatOptions.default("width") == 80
+    assert FormatOptions.default("compact") == False
+    assert FormatOptions.default("indent_type") == IndentType.NONE()
+    assert FormatOptions.default("text_style") == TextStyle()
+    assert FormatOptions.default("style_entire_text") == False
+    assert FormatOptions.default("strict_type_matching") == False
+    assert FormatOptions.default("projections") is None
+    assert FormatOptions.default("formatters") is None
+
+
 def test_init_with_none_text_style():
     sut = FormatOptions(text_style=None)
     assert sut.text_style == TextStyle()
@@ -21,11 +32,3 @@ def test_asdict_shallow():
 def test_asdict_deep():
     sut = FormatOptions()
     assert sut.asdict(shallow=False) == asdict(sut)
-
-
-def test_default():
-    assert FormatOptions.default("width") == 80
-    assert FormatOptions.default("indent_type") == IndentType.NONE()
-    assert FormatOptions.default("compact") == False
-    assert FormatOptions.default("projections") is None
-    assert FormatOptions.default("formatters") is None

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -8,18 +8,8 @@ from colored import Back, Fore, Style
 from pformat.format_options import FormatOptions
 from pformat.formatter_types import normal_formatter
 from pformat.indentation_utility import IndentType
-from pformat.pretty_formatter import IterableFormatter, PrettyFormatter
+from pformat.pretty_formatter import IterableFormatter, MappingFormatter, PrettyFormatter
 from pformat.text_style import TextStyle
-
-
-def test_iterable_formatter_get_parnens():
-    assert IterableFormatter.get_parens(list()) == ("[", "]")
-    assert IterableFormatter.get_parens(set()) == ("{", "}")
-    assert IterableFormatter.get_parens(frozenset()) == ("frozen{", "}")
-    assert IterableFormatter.get_parens(tuple()) == ("(", ")")
-    assert IterableFormatter.get_parens(range(3)) == ("(", ")")
-    assert IterableFormatter.get_parens(deque()) == ("deque([", "])")
-    assert IterableFormatter.get_parens(DummyIterable()) == (f"{DummyIterable.__name__}(", ")")
 
 
 class TestPrettyFormatterInitialization:
@@ -395,3 +385,40 @@ class TestPrettyFormatterCustomFormatters:
         default_formatter = PrettyFormatter()
 
         assert all(sut(value) == default_formatter(value) for value in default_type_values)
+
+
+class TestIterableFormatter:
+    def test_init_default(self):
+        fmt = PrettyFormatter.new()
+        sut = IterableFormatter(fmt)
+
+        assert sut.type is Iterable
+
+    def test_init_with_strict_type_matching(self):
+        fmt = PrettyFormatter.new(strict_type_matching=True)
+        sut = IterableFormatter(fmt)
+
+        assert sut.type is IterableFormatter._TYPES
+
+    def test_get_parnens(self):
+        assert IterableFormatter.get_parens(list()) == ("[", "]")
+        assert IterableFormatter.get_parens(set()) == ("{", "}")
+        assert IterableFormatter.get_parens(frozenset()) == ("frozen{", "}")
+        assert IterableFormatter.get_parens(tuple()) == ("(", ")")
+        assert IterableFormatter.get_parens(range(3)) == ("(", ")")
+        assert IterableFormatter.get_parens(deque()) == ("deque([", "])")
+        assert IterableFormatter.get_parens(DummyIterable()) == (f"{DummyIterable.__name__}(", ")")
+
+
+class TestMappingFormatter:
+    def test_init_default(self):
+        fmt = PrettyFormatter.new()
+        sut = MappingFormatter(fmt)
+
+        assert sut.type is Mapping
+
+    def test_init_with_strict_type_matching(self):
+        fmt = PrettyFormatter.new(strict_type_matching=True)
+        sut = MappingFormatter(fmt)
+
+        assert sut.type is MappingFormatter._TYPES


### PR DESCRIPTION
Added:
- support for union types to the `TypeFormatter` classes
- the `strict_type_matching` attribute to the `FormatOptions` and `PrettyFormatter` classes