### PR TITLE
YT-PYPF-18: Add a general-purpose Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+.PHONY: tests clean_tests coverage clean_cov build clean_build ruff clean_ruff clean_all install upload
+
+tests-simple:
+	pytest test/
+
+# tox will generate the coverage report
+tests-tox:
+	tox
+
+clean-tests:
+	rm -rf .pytest_cache/ .tox/
+
+clean-cov:
+	rm -rf .coverage*
+
+build:
+	python -m build
+
+clean-build:
+	rm -rf build/ dist/ *.egg-info README_pypi.md
+
+ruff:
+	ruff format && ruff check --fix
+
+clean-ruff:
+	rm -rf .ruff_cache/
+
+clean-all: clean-tests clean-cov clean-build clean-ruff
+
+install:
+	pip uninstall -y pypformat || true
+	$(MAKE) clean-build
+	python -m build
+	pip install .
+
+upload: build
+	python scripts/preprocess_md_doc.py
+	python -m twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,6 @@ clean-all: clean-venv clean-tests clean-cov clean-build clean-ruff
 
 install:
 	$(PYM) pip uninstall -y pypformat || true
-	$(MAKE) clean-build
-	$(PYM) build
 	$(PYM) install .
 
 upload: build

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ clean-build:
 	rm -rf build/ dist/ *.egg-info README_pypi.md
 
 ruff:
-	ruff format && ruff check --fix
+	$(PYM) ruff format && ruff check --fix
 
 clean-ruff:
 	rm -rf .ruff_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,38 @@
-.PHONY: tests clean_tests coverage clean_cov build clean_build ruff clean_ruff clean_all install upload
+PY := python3
+PYM := $(PY) -m
+
+.PHONY: \
+	prepare-venv \
+	clean-venv \
+	tests-simple \
+	tests-tox \
+	clean-tests \
+	clean-cov \
+	build \
+	clean-build \
+	ruff \
+	clean-ruff \
+	clean-all \
+	install \
+	upload
+
+prepare-venv:
+	$(PYM) venv venv && \
+	. venv/bin/activate && \
+	pip install -r requirements-dev.txt
+
+clean-venv:
+	rm -rf venv/
+
+source-venv:
+	. venv/bin/activate
 
 tests-simple:
-	pytest test/
+	$(PYM) pytest test/
 
 # tox will generate the coverage report
 tests-tox:
-	tox
+	$(PYM) tox
 
 clean-tests:
 	rm -rf .pytest_cache/ .tox/
@@ -14,7 +41,8 @@ clean-cov:
 	rm -rf .coverage*
 
 build:
-	python -m build
+	$(PYM) build
+	$(PY) scripts/preprocess_md_doc.py
 
 clean-build:
 	rm -rf build/ dist/ *.egg-info README_pypi.md
@@ -25,14 +53,13 @@ ruff:
 clean-ruff:
 	rm -rf .ruff_cache/
 
-clean-all: clean-tests clean-cov clean-build clean-ruff
+clean-all: clean-venv clean-tests clean-cov clean-build clean-ruff
 
 install:
-	pip uninstall -y pypformat || true
+	$(PYM) pip uninstall -y pypformat || true
 	$(MAKE) clean-build
-	python -m build
-	pip install .
+	$(PYM) build
+	$(PYM) install .
 
 upload: build
-	python scripts/preprocess_md_doc.py
-	python -m twine upload dist/*
+	$(PYM) twine upload dist/*

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -3,7 +3,7 @@
 - [Dev environment](#dev-environment)
 - [Formatting and linting](#formatting-and-linting)
 - [Testing](#testing)
-- [Other]()
+- [Other](#other)
 
 <br />
 <br />

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -3,23 +3,24 @@
 - [Dev environment](#dev-environment)
 - [Formatting and linting](#formatting-and-linting)
 - [Testing](#testing)
+- [Other]()
 
 <br />
 <br />
 
 ## Dev environment
 
-To create a complete development environment for the `PyPformat` project create a virtual environment and install the required dependencies:
+To create a complete development environment for the `PyPformat` project create a virtual environment and install the required dependencies. You can do it by running:
 
 ```shell
-pip install -r requirements-dev.txt
+make prepare-venv
+source venv/bin/activate
 ```
 
 To run the project examples, you must install the project itself into the environment with:
 
 ```shell
-cd <pypformat-root>
-pip install .
+make install
 ```
 
 <br />
@@ -36,6 +37,13 @@ ruff check # linter
 ruff format # (--check) - formatter
 ```
 
+or
+
+```shell
+make ruff
+# equivalent to: ruff format && ruff check --fix
+```
+
 <br />
 <br />
 
@@ -47,3 +55,32 @@ Alternatively, you can run the `tox` command to run tests for all supported pyth
 
 > [!TIP]
 > The `tox.ini` configuration file is prepared with CI testing in mind, therefore it will fail if any of the supported python versions is not available. To fix that, you can set the `skip_missing_interpreters` option to `True` **locally**.
+
+<br />
+<br />
+
+## Other
+
+The [Makefile](/Makefile) defines a few utility targets which can be used to parform actions like running tests, building the project, cleaning temorary files, etc.
+
+These targets include:
+
+```shell
+prepare-venv    # prepare the virtual environment
+clean-venv      # remove the virtual environment
+tests-simple    # run tests directly using pytest
+tests-tox       # run test using tox and generate the coverage report
+clean-tests     # clean the test-related temporary files
+clean-cov       # clean the coverage-related temporary files
+build           # build the project/package
+clean-build     # clean the build files
+ruff            # run the ruff formatter and linter
+clean-ruff      # clean ruff temporary files
+clean-all       # clean all temporary files
+install         # install the project to the current envinronment
+upload          # upload the distribution files to pypi (requires access to the pypi project)
+```
+
+> [!NOTE]
+>
+> Apart from `prepare-venv` and `clean-*` all targets require to be sourced to a valid project environment within the current shell session (e.g. by using `source venv/bin/activate` if you've used the `prepare-venv`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pypformat"
-version = "1.2.0"
+version = "1.2.1"
 description = "Python pretty formatting package"
 authors = [
   {name = "SpectraL519"}

--- a/scripts/preprocess_md_doc.py
+++ b/scripts/preprocess_md_doc.py
@@ -26,7 +26,7 @@ def parse_args():
         "-o",
         "--output-file",
         type=Path,
-        default="README_preprocessed.md",
+        default="README_pypi.md",
         help="Path to the output README file.",
     )
     parser.add_argument(

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -8,7 +8,7 @@ from colored import Back, Fore, Style
 
 from pformat.format_options import FormatOptions
 from pformat.indentation_utility import IndentType
-from pformat.named_types import NamedMapping, NamedIterable
+from pformat.named_types import NamedIterable, NamedMapping
 from pformat.pretty_formatter import (
     IterableFormatter,
     MappingFormatter,

--- a/test/test_pretty_formatter.py
+++ b/test/test_pretty_formatter.py
@@ -8,7 +8,7 @@ from colored import Back, Fore, Style
 
 from pformat.format_options import FormatOptions
 from pformat.indentation_utility import IndentType
-from pformat.named_types import NamedMapping
+from pformat.named_types import NamedMapping, NamedIterable
 from pformat.pretty_formatter import (
     IterableFormatter,
     MappingFormatter,
@@ -49,12 +49,18 @@ INDENT_TYPE_VALS = [
     gen(width=w)
     for gen, w in product([IndentType.NONE, IndentType.DOTS, IndentType.LINE], INDENT_WIDTH_VALS)
 ]
-RECOGNIZED_ITERABLE_TYPES = [list, UserList, set, frozenset, tuple, deque]
+RECOGNIZED_ITERABLE_TYPES = [list, UserList, set, frozenset, tuple, deque, NamedIterable]
 RECOGNIZED_NHASH_ITERABLE_TYPES = [list, UserList, tuple, deque]
 RECOGNIZED_MAPPING_TYPES = MappingFormatter._TYPES.__args__
 
 INT_UNBOUND = 10e9
 NESTED_MAPPING_KEY = "nested_elem"
+
+
+def gen_iterable(data: Iterable, t: type = list) -> Iterable:
+    if issubclass(t, NamedIterable):
+        return t("DummyNamedIterable", data)
+    return t(data)
 
 
 def gen_mapping(data: Iterable, t: type = dict, nested: bool = False) -> Mapping:
@@ -84,7 +90,7 @@ class TestPrettyFormatterSimple:
 
     @pytest.mark.parametrize("iterable_type", RECOGNIZED_ITERABLE_TYPES)
     def test_format_iterable(self, sut: PrettyFormatter, iterable_type: type):
-        collection = iterable_type(SIMPLE_HASHABLE_DATA)
+        collection = gen_iterable(SIMPLE_HASHABLE_DATA, iterable_type)
         opening, closing = IterableFormatter.get_parens(collection)
 
         expected_output = "\n".join(
@@ -175,7 +181,7 @@ class TestPrettyFormatterCompact:
 
     @pytest.mark.parametrize("iterable_type", RECOGNIZED_ITERABLE_TYPES)
     def test_format_iterable(self, sut: PrettyFormatter, iterable_type: type):
-        collection = iterable_type(SIMPLE_HASHABLE_DATA)
+        collection = gen_iterable(SIMPLE_HASHABLE_DATA, iterable_type)
         opening, closing = IterableFormatter.get_parens(collection)
 
         expected_output = opening + ", ".join(repr(value) for value in collection) + closing


### PR DESCRIPTION
- Added a `Makefile` with the following targets:
  ```
  prepare-venv    # prepare the virtual environment
  clean-venv      # remove the virtual environment
  tests-simple    # run tests directly using pytest
  tests-tox       # run test using tox and generate the coverage report
  clean-tests     # clean the test-related temporary files
  clean-cov       # clean the coverage-related temporary files
  build           # build the project/package
  clean-build     # clean the build files
  ruff            # run the ruff formatter and linter
  clean-ruff      # clean ruff temporary files
  clean-all       # clean all temporary files
  install         # install the project to the current envinronment
  upload          # upload the distribution files to pypi (requires access to the pypi project)
  ```
- Extended the `PrettyFormatter` tests to validate the behaviour for `NamedIterable`